### PR TITLE
Rune buy offers

### DIFF
--- a/crates/mockcore/src/server.rs
+++ b/crates/mockcore/src/server.rs
@@ -1066,7 +1066,7 @@ impl Api for Server {
 
         let txout = &tx.output[usize::try_from(input.previous_output.vout).unwrap()];
 
-        let address = Address::from_script(&txout.script_pubkey, Network::Bitcoin).unwrap();
+        let address = Address::from_script(&txout.script_pubkey, self.network).unwrap();
 
         if self.state().is_wallet_address(&address) {
           balance_change -= i64::try_from(txout.value.to_sat()).unwrap();
@@ -1074,7 +1074,7 @@ impl Api for Server {
       }
 
       for output in tx.output {
-        let address = Address::from_script(&output.script_pubkey, Network::Bitcoin).unwrap();
+        let address = Address::from_script(&output.script_pubkey, self.network).unwrap();
         if self.state().is_wallet_address(&address) {
           balance_change += i64::try_from(output.value.to_sat()).unwrap();
         }

--- a/crates/mockcore/src/server.rs
+++ b/crates/mockcore/src/server.rs
@@ -1074,10 +1074,6 @@ impl Api for Server {
       }
 
       for output in tx.output {
-        if output.script_pubkey.is_op_return() {
-          continue;
-        }
-
         let address = Address::from_script(&output.script_pubkey, self.network).unwrap();
         if self.state().is_wallet_address(&address) {
           balance_change += i64::try_from(output.value.to_sat()).unwrap();

--- a/crates/mockcore/src/server.rs
+++ b/crates/mockcore/src/server.rs
@@ -1074,6 +1074,10 @@ impl Api for Server {
       }
 
       for output in tx.output {
+        if output.script_pubkey.is_op_return() {
+          continue;
+        }
+
         let address = Address::from_script(&output.script_pubkey, self.network).unwrap();
         if self.state().is_wallet_address(&address) {
           balance_change += i64::try_from(output.value.to_sat()).unwrap();

--- a/docs/src/guides/wallet.md
+++ b/docs/src/guides/wallet.md
@@ -446,3 +446,45 @@ Once the send transaction confirms, you can confirm receipt by running:
 ```
 ord wallet inscriptions
 ```
+
+Creating an Inscription or Runes Buy Offer
+---------------------------------------
+
+Bid `AMOUNT` on the inscription `INSCRIPTION_ID` using:
+
+```
+ord wallet offer create --inscription <INSCRIPTION_ID> --fee-rate <FEE_RATE> --amount <AMOUNT>
+```
+
+Bid `AMOUNT` on the rune balance `DECIMAL:RUNE` at `UTXO` using:
+
+```
+ord wallet offer create --rune <DECIMAL:RUNE> --fee-rate <FEE_RATE> --amount <AMOUNT> --utxo <UTXO>
+```
+
+Accepting an Inscription or Runes Buy Offer
+----------------------------------------
+
+Accept the offer to buy the inscription `INSCRIPTION_ID` for `AMOUNT` via `PSBT` using:
+
+```
+ord wallet offer accept --inscription <INSCRIPTION_ID> --amount <AMOUNT> --psbt <PSBT>
+```
+
+Accept the offer to buy the rune balance `DECIMAL:RUNE` sold in `PSBT` using:
+
+```
+ord wallet offer accept --rune <DECIMAL:RUNE> --amount <AMOUNT> --psbt <PSBT>
+```
+
+See the pending transaction with:
+
+```
+ord wallet transactions
+```
+
+Once the accept transaction confirms, you can view your updated balance with:
+
+```
+ord wallet balance
+```

--- a/docs/src/guides/wallet.md
+++ b/docs/src/guides/wallet.md
@@ -448,7 +448,7 @@ ord wallet inscriptions
 ```
 
 Creating an Inscription or Runes Buy Offer
----------------------------------------
+------------------------------------------
 
 Bid `AMOUNT` on the inscription `INSCRIPTION_ID` using:
 
@@ -463,7 +463,7 @@ ord wallet offer create --rune <DECIMAL:RUNE> --fee-rate <FEE_RATE> --amount <AM
 ```
 
 Accepting an Inscription or Runes Buy Offer
-----------------------------------------
+-------------------------------------------
 
 Accept the offer to buy the inscription `INSCRIPTION_ID` for `AMOUNT` via `PSBT` using:
 

--- a/docs/src/guides/wallet.md
+++ b/docs/src/guides/wallet.md
@@ -465,13 +465,13 @@ ord wallet offer create --rune <DECIMAL:RUNE> --fee-rate <FEE_RATE> --amount <AM
 Accepting an Inscription or Runes Buy Offer
 -------------------------------------------
 
-Accept the offer to buy the inscription `INSCRIPTION_ID` for `AMOUNT` via `PSBT` using:
+Accept the offer to buy the inscription `INSCRIPTION_ID` for `AMOUNT` in `PSBT` using:
 
 ```
 ord wallet offer accept --inscription <INSCRIPTION_ID> --amount <AMOUNT> --psbt <PSBT>
 ```
 
-Accept the offer to buy the rune balance `DECIMAL:RUNE` sold in `PSBT` using:
+Accept the offer to buy the rune balance `DECIMAL:RUNE` in `PSBT` using:
 
 ```
 ord wallet offer accept --rune <DECIMAL:RUNE> --amount <AMOUNT> --psbt <PSBT>

--- a/src/subcommand/wallet/offer/accept.rs
+++ b/src/subcommand/wallet/offer/accept.rs
@@ -215,7 +215,7 @@ impl Accept {
           utxo,
           inscriptions.len()
         }
-      };
+      }
 
       let Some(pile) = runes.get(&spaced_rune) else {
         bail!(format!(

--- a/src/subcommand/wallet/offer/accept.rs
+++ b/src/subcommand/wallet/offer/accept.rs
@@ -12,6 +12,10 @@ pub struct Output {
 }
 
 #[derive(Debug, Parser)]
+#[command(group = ArgGroup::new("target")
+  .required(true)
+  .multiple(false)
+  .args(["inscription", "rune"]))]
 pub(crate) struct Accept {
   #[arg(long, help = "Assert offer is for <AMOUNT>")]
   amount: Amount,
@@ -39,15 +43,103 @@ impl Accept {
       }
     }
 
+    ensure! {
+      outgoing.len() <= 1,
+      "PSBT contains {} inputs owned by wallet", outgoing.len(),
+    }
+
+    let Some((index, outgoing)) = outgoing.into_iter().next() else {
+      bail!("PSBT contains no inputs owned by wallet");
+    };
+
     match (self.inscription, self.rune.clone()) {
-      (Some(inscription), None) => {
-        self.check_inscription_buy_offer(&wallet, outgoing.clone(), inscription)?
+      (Some(inscription_id), None) => {
+        if let Some(runes) = wallet.get_runes_balances_in_output(&outgoing)? {
+          ensure! {
+            runes.is_empty(),
+            "outgoing input {} contains runes", outgoing,
+          }
+        }
+
+        let Some(inscriptions) = wallet.get_inscriptions_in_output(&outgoing)? else {
+          bail! {
+            "index must have inscription index to accept PSBT",
+          }
+        };
+
+        ensure! {
+          inscriptions.len() <= 1,
+          "outgoing input {} contains {} inscriptions", outgoing, inscriptions.len(),
+        }
+
+        let Some(inscription) = inscriptions.into_iter().next() else {
+          bail!("outgoing input contains no inscriptions");
+        };
+
+        ensure! {
+          inscription == inscription_id,
+          "unexpected outgoing inscription {inscription}",
+        }
       }
       (None, Some(rune)) => {
-        self.check_rune_buy_offer(&wallet, psbt.unsigned_tx.clone(), outgoing.clone(), rune)?
+        let (decimal, spaced_rune) = match rune {
+          Outgoing::Rune { decimal, rune } => (decimal, rune),
+          _ => bail!("invalid format for --rune (must be `DECIMAL:RUNE`)"),
+        };
+
+        ensure!(
+          wallet.has_rune_index(),
+          "accepting rune offer with `offer` requires index created with `--index-runes` flag",
+        );
+
+        wallet
+          .get_rune(spaced_rune.rune)?
+          .with_context(|| format!("rune `{}` has not been etched", spaced_rune.rune))?;
+
+        let Some(runes) = wallet.get_runes_balances_in_output(&outgoing)? else {
+          bail! {
+            "outgoing input {} contains no runes",
+            outgoing
+          }
+        };
+
+        if let Some(inscriptions) = wallet.get_inscriptions_in_output(&outgoing)? {
+          ensure! {
+            inscriptions.is_empty(),
+            "outgoing input {} contains {} inscription(s)",
+            outgoing,
+            inscriptions.len()
+          }
+        }
+
+        let Some(pile) = runes.get(&spaced_rune) else {
+          bail!(format!(
+            "outgoing input {} does not contain rune {}",
+            outgoing, spaced_rune
+          ));
+        };
+
+        ensure! {
+          runes.len() == 1,
+          "outgoing input {} holds multiple runes",
+          outgoing
+        }
+
+        ensure! {
+          pile.amount == decimal.value,
+          "unexpected rune {} balance at outgoing input {} (expected {}, found {})",
+          spaced_rune,
+          outgoing,
+          decimal.value,
+          pile.amount
+        }
+
+        ensure! {
+          Runestone::decipher(&psbt.unsigned_tx).is_none(),
+          "unexpected runestone in PSBT"
+        }
       }
-      (None, None) => bail!("must include either --inscription or --rune"),
-      (Some(_), Some(_)) => bail!("cannot include both --inscription and --rune"),
+      _ => unreachable!("--inscription or --rune must be set, but not both"),
     }
 
     let balance_change = wallet.simulate_transaction(&psbt.unsigned_tx)?;
@@ -62,7 +154,7 @@ impl Accept {
     for (i, signature) in signatures.iter().enumerate() {
       let outpoint = psbt.unsigned_tx.input[i].previous_output;
 
-      if outgoing.contains_key(&i) {
+      if i == index {
         ensure! {
           signature.is_none(),
           "seller input `{outpoint}` is signed: seller input must not be signed",
@@ -106,7 +198,7 @@ impl Accept {
         {
           let outpoint = signed_tx.input[i].previous_output;
 
-          if outgoing.contains_key(&i) {
+          if i == index {
             ensure! {
               new.is_some(),
               "seller input `{outpoint}` was not signed by wallet",
@@ -124,152 +216,6 @@ impl Accept {
     };
 
     Ok(Some(Box::new(Output { txid })))
-  }
-
-  fn check_inscription_buy_offer(
-    &self,
-    wallet: &Wallet,
-    outgoing: BTreeMap<usize, OutPoint>,
-    inscription_id: InscriptionId,
-  ) -> Result {
-    ensure! {
-      outgoing.len() <= 1,
-      "PSBT contains {} inputs owned by wallet", outgoing.len(),
-    }
-
-    let Some((_, outgoing)) = outgoing.into_iter().next() else {
-      bail!("PSBT contains no inputs owned by wallet");
-    };
-
-    if let Some(runes) = wallet.get_runes_balances_in_output(&outgoing)? {
-      ensure! {
-        runes.is_empty(),
-        "outgoing input {} contains runes", outgoing,
-      }
-    }
-
-    let Some(inscriptions) = wallet.get_inscriptions_in_output(&outgoing)? else {
-      bail! {
-        "index must have inscription index to accept PSBT",
-      }
-    };
-
-    ensure! {
-      inscriptions.len() <= 1,
-      "outgoing input {} contains {} inscriptions", outgoing, inscriptions.len(),
-    }
-
-    let Some(inscription) = inscriptions.into_iter().next() else {
-      bail!("outgoing input contains no inscriptions");
-    };
-
-    ensure! {
-      inscription == inscription_id,
-      "unexpected outgoing inscription {inscription}",
-    }
-
-    Ok(())
-  }
-
-  fn check_rune_buy_offer(
-    &self,
-    wallet: &Wallet,
-    unsigned_tx: Transaction,
-    outgoing: BTreeMap<usize, OutPoint>,
-    rune: Outgoing,
-  ) -> Result {
-    ensure! {
-      !outgoing.is_empty(),
-      "PSBT contains no inputs owned by wallet"
-    }
-
-    let (decimal, spaced_rune) = match rune {
-      Outgoing::Rune { decimal, rune } => (decimal, rune),
-      _ => bail!("invalid format for --rune (must be `DECIMAL:RUNE`)"),
-    };
-
-    ensure!(
-      wallet.has_rune_index(),
-      "accepting rune offer with `offer` requires index created with `--index-runes` flag",
-    );
-
-    let (id, _, _) = wallet
-      .get_rune(spaced_rune.rune)?
-      .with_context(|| format!("rune `{}` has not been etched", spaced_rune.rune))?;
-
-    let mut contains_multiple_runes = false;
-    let mut amount = 0;
-
-    for utxo in outgoing.values() {
-      let Some(runes) = wallet.get_runes_balances_in_output(utxo)? else {
-        bail! {
-          "outgoing input {} contains no runes",
-          utxo
-        }
-      };
-
-      if let Some(inscriptions) = wallet.get_inscriptions_in_output(utxo)? {
-        ensure! {
-          inscriptions.is_empty(),
-          "outgoing input {} contains {} inscription(s)",
-          utxo,
-          inscriptions.len()
-        }
-      }
-
-      let Some(pile) = runes.get(&spaced_rune) else {
-        bail!(format!(
-          "outgoing input {} does not contain rune {}",
-          utxo, spaced_rune
-        ));
-      };
-
-      contains_multiple_runes = contains_multiple_runes || runes.len() > 1;
-      amount += pile.amount;
-    }
-
-    ensure! {
-      amount == decimal.value,
-      "unexpected rune {} balance at outgoing input(s) ({} vs. {})",
-      spaced_rune,
-      amount,
-      decimal.value
-    }
-
-    if contains_multiple_runes {
-      let Some(runestone) = Runestone::decipher(&unsigned_tx) else {
-        bail!("missing runestone in PSBT");
-      };
-
-      let expected_runestone = Runestone {
-        edicts: vec![Edict {
-          amount: 0,
-          id,
-          output: 2,
-        }],
-        ..default()
-      };
-
-      ensure! {
-        runestone == Artifact::Runestone(expected_runestone),
-        "unexpected runestone in PSBT"
-      }
-
-      ensure! {
-        !unsigned_tx.output.is_empty() &&
-        outgoing.values().any(|outgoing| {
-          unsigned_tx.output[0].script_pubkey == wallet.utxos().get(outgoing).unwrap().script_pubkey
-        }),
-        "unexpected seller address in PSBT"
-      }
-    } else {
-      ensure! {
-        Runestone::decipher(&unsigned_tx).is_none(),
-        "unexpected runestone in PSBT"
-      }
-    }
-
-    Ok(())
   }
 
   fn psbt_signatures(psbt: &Psbt) -> Result<Vec<Option<Signature>>> {

--- a/src/subcommand/wallet/offer/create.rs
+++ b/src/subcommand/wallet/offer/create.rs
@@ -4,48 +4,92 @@ use super::*;
 pub struct Output {
   pub psbt: String,
   pub seller_address: Address<NetworkUnchecked>,
-  pub inscription: InscriptionId,
+  pub inscription: Option<InscriptionId>,
+  pub rune: Option<Outgoing>,
 }
 
 #[derive(Debug, Parser)]
 pub(crate) struct Create {
   #[arg(long, help = "<INSCRIPTION> to make offer for.")]
-  inscription: InscriptionId,
+  inscription: Option<InscriptionId>,
+  #[arg(long, help = "<DECIMAL:RUNE> to make offer for.")]
+  rune: Option<Outgoing>,
   #[arg(long, help = "<AMOUNT> to offer.")]
   amount: Amount,
   #[arg(long, help = "<FEE_RATE> for finalized transaction.")]
   fee_rate: FeeRate,
+  #[arg(long, help = "UTXO to make an offer for. (format: <TXID:VOUT>)")]
+  utxo: Option<OutPoint>,
+  #[arg(
+    long,
+    help = "Include at least <AMOUNT> postage with receive output. [default: 10000sat]"
+  )]
+  postage: Option<Amount>,
 }
 
 impl Create {
   pub(crate) fn run(&self, wallet: Wallet) -> SubcommandResult {
+    let (psbt, seller_address) = match (self.inscription, self.rune.clone()) {
+      (Some(inscription), None) => self.create_inscription_buy_offer(wallet, inscription)?,
+      (None, Some(outgoing)) => self.create_rune_buy_offer(wallet, outgoing)?,
+      _ => bail!("outgoing must be either <INSCRIPTION> or <DECIMAL:RUNE>"),
+    };
+
+    Ok(Some(Box::new(Output {
+      psbt,
+      seller_address,
+      inscription: self.inscription,
+      rune: self.rune.clone(),
+    })))
+  }
+
+  fn create_inscription_buy_offer(
+    &self,
+    wallet: Wallet,
+    inscription_id: InscriptionId,
+  ) -> Result<(String, Address<NetworkUnchecked>)> {
     ensure!(
-      !wallet.inscription_info().contains_key(&self.inscription),
+      !wallet.inscription_info().contains_key(&inscription_id),
       "inscription {} already in wallet",
-      self.inscription
+      inscription_id
     );
 
-    let Some(inscription) = wallet.get_inscription(self.inscription)? else {
-      bail!("inscription {} does not exist", self.inscription);
+    let Some(inscription) = wallet.get_inscription(inscription_id)? else {
+      bail!("inscription {} does not exist", inscription_id);
     };
 
     let Some(postage) = inscription.value else {
-      bail!("inscription {} unbound", self.inscription);
+      bail!("inscription {} unbound", inscription_id);
     };
 
     let Some(seller_address) = inscription.address else {
       bail!(
         "inscription {} script pubkey not valid address",
-        self.inscription,
+        inscription_id,
       );
     };
+
+    if let Some(utxo) = self.utxo {
+      ensure! {
+        inscription.satpoint.outpoint == utxo,
+        "inscription utxo {} does not match provided utxo {}",
+        inscription.satpoint.outpoint,
+        utxo
+      };
+    }
 
     let seller_address = seller_address
       .parse::<Address<NetworkUnchecked>>()
       .unwrap()
       .require_network(wallet.chain().network())?;
 
-    let postage = Amount::from_sat(postage);
+    let seller_postage = Amount::from_sat(postage);
+
+    let mut buyer_postage = self.postage.unwrap_or(TARGET_POSTAGE);
+
+    if seller_postage > buyer_postage {
+      buyer_postage = seller_postage;
+    }
 
     let tx = Transaction {
       version: Version(2),
@@ -58,16 +102,131 @@ impl Create {
       }],
       output: vec![
         TxOut {
-          value: postage,
+          value: buyer_postage,
           script_pubkey: wallet.get_change_address()?.into(),
         },
         TxOut {
-          value: self.amount + postage,
+          value: self.amount + seller_postage,
           script_pubkey: seller_address.clone().into(),
         },
       ],
     };
 
+    let psbt = self.create_funded_buy_offer(wallet, tx)?;
+
+    Ok((psbt, seller_address.into_unchecked()))
+  }
+
+  fn create_rune_buy_offer(
+    &self,
+    wallet: Wallet,
+    outgoing: Outgoing,
+  ) -> Result<(String, Address<NetworkUnchecked>)> {
+    let (decimal, spaced_rune) = match outgoing {
+      Outgoing::Rune { decimal, rune } => (decimal, rune),
+      _ => bail!("invalid format for --rune (must be `DECIMAL:RUNE`)"),
+    };
+
+    ensure!(
+      wallet.has_rune_index(),
+      "creating runes offer with `buy-offer` requires index created with `--index-runes` flag",
+    );
+
+    wallet
+      .get_rune(spaced_rune.rune)?
+      .with_context(|| format!("rune `{}` has not been etched", spaced_rune.rune))?;
+
+    let Some(utxo) = self.utxo else {
+      bail!("--utxo must be set");
+    };
+
+    ensure!(
+      !wallet.utxos().contains_key(&utxo),
+      "utxo {} already in wallet",
+      utxo
+    );
+
+    ensure! {
+      wallet.output_exists(utxo)?,
+      "utxo {} does not exist",
+      utxo
+    }
+
+    let Some(output_info) = wallet.get_output_info(utxo)? else {
+      bail!("utxo {} does not exist", utxo);
+    };
+
+    let Some(seller_address) = output_info.address else {
+      bail!("utxo {} script pubkey not valid address", utxo);
+    };
+
+    let Some(runes) = output_info.runes else {
+      bail!("utxo {} does not hold any runes", utxo);
+    };
+
+    let Some(pile) = runes.get(&spaced_rune) else {
+      bail!("utxo {} does not hold any {} runes", utxo, spaced_rune);
+    };
+
+    ensure! {
+      runes.len() == 1,
+      "utxo {} holds multiple runes",
+      utxo
+    };
+
+    if pile.amount < decimal.value {
+      bail!(
+        "utxo {} holds less {} than required ({} < {})",
+        utxo,
+        spaced_rune,
+        pile.amount,
+        decimal.value,
+      );
+    }
+
+    if pile.amount > decimal.value {
+      bail!(
+        "utxo {} holds more {} than expected ({} > {})",
+        utxo,
+        spaced_rune,
+        pile.amount,
+        decimal.value,
+      );
+    }
+
+    let buyer_postage = self.postage.unwrap_or(TARGET_POSTAGE);
+
+    let seller_postage = Amount::from_sat(output_info.value);
+
+    let seller_address = seller_address.require_network(wallet.chain().network())?;
+
+    let tx = Transaction {
+      version: Version(2),
+      lock_time: LockTime::ZERO,
+      input: vec![TxIn {
+        previous_output: utxo,
+        script_sig: ScriptBuf::new(),
+        sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+        witness: Witness::new(),
+      }],
+      output: vec![
+        TxOut {
+          value: buyer_postage,
+          script_pubkey: wallet.get_change_address()?.into(),
+        },
+        TxOut {
+          value: self.amount + seller_postage,
+          script_pubkey: seller_address.clone().into(),
+        },
+      ],
+    };
+
+    let psbt = self.create_funded_buy_offer(wallet, tx)?;
+
+    Ok((psbt, seller_address.into_unchecked()))
+  }
+
+  fn create_funded_buy_offer(&self, wallet: Wallet, tx: Transaction) -> Result<String> {
     wallet.lock_non_cardinal_outputs()?;
 
     let tx = fund_raw_transaction(wallet.bitcoin_client(), self.fee_rate, &tx)?;
@@ -89,10 +248,6 @@ impl Create {
       "PSBT unexpectedly complete after processing with wallet",
     }
 
-    Ok(Some(Box::new(Output {
-      psbt: result.psbt,
-      inscription: self.inscription,
-      seller_address: seller_address.into_unchecked(),
-    })))
+    Ok(result.psbt)
   }
 }

--- a/src/subcommand/wallet/offer/create.rs
+++ b/src/subcommand/wallet/offer/create.rs
@@ -32,7 +32,8 @@ impl Create {
     let (psbt, seller_address) = match (self.inscription, self.rune.clone()) {
       (Some(inscription), None) => self.create_inscription_buy_offer(wallet, inscription)?,
       (None, Some(outgoing)) => self.create_rune_buy_offer(wallet, outgoing)?,
-      _ => bail!("outgoing must be either <INSCRIPTION> or <DECIMAL:RUNE>"),
+      (None, None) => bail!("must include either --inscription or --rune"),
+      (Some(_), Some(_)) => bail!("cannot include both --inscription and --rune"),
     };
 
     Ok(Some(Box::new(Output {

--- a/src/subcommand/wallet/offer/create.rs
+++ b/src/subcommand/wallet/offer/create.rs
@@ -9,6 +9,10 @@ pub struct Output {
 }
 
 #[derive(Debug, Parser)]
+#[command(group = ArgGroup::new("target")
+  .required(true)
+  .multiple(false)
+  .args(["inscription", "rune"]))]
 pub(crate) struct Create {
   #[arg(long, help = "<INSCRIPTION> to make offer for.")]
   inscription: Option<InscriptionId>,
@@ -19,264 +23,143 @@ pub(crate) struct Create {
   #[arg(long, help = "<FEE_RATE> for finalized transaction.")]
   fee_rate: FeeRate,
   #[arg(long, help = "UTXO to make an offer for. (format: <TXID:VOUT>)")]
-  utxo: Vec<OutPoint>,
-  #[arg(
-    long,
-    help = "Include at least <AMOUNT> postage with receive output. [default: 10000sat]"
-  )]
-  postage: Option<Amount>,
+  utxo: Option<OutPoint>,
 }
 
 impl Create {
   pub(crate) fn run(&self, wallet: Wallet) -> SubcommandResult {
-    let (psbt, seller_address) = match (self.inscription, self.rune.clone()) {
-      (Some(inscription), None) => self.create_inscription_buy_offer(wallet, inscription)?,
-      (None, Some(outgoing)) => self.create_rune_buy_offer(wallet, outgoing)?,
-      (None, None) => bail!("must include either --inscription or --rune"),
-      (Some(_), Some(_)) => bail!("cannot include both --inscription and --rune"),
+    let (seller_address, postage, utxo) = match (self.inscription, self.rune.clone()) {
+      (Some(inscription_id), None) => {
+        ensure!(
+          !wallet.inscription_info().contains_key(&inscription_id),
+          "inscription {} already in wallet",
+          inscription_id
+        );
+
+        let Some(inscription) = wallet.get_inscription(inscription_id)? else {
+          bail!("inscription {} does not exist", inscription_id);
+        };
+
+        if let Some(utxo) = self.utxo {
+          ensure! {
+            inscription.satpoint.outpoint == utxo,
+            "inscription utxo {} does not match provided utxo {}",
+            inscription.satpoint.outpoint,
+            utxo
+          };
+        }
+
+        let Some(postage) = inscription.value else {
+          bail!("inscription {} unbound", inscription_id);
+        };
+
+        let Some(seller_address) = inscription.address else {
+          bail!(
+            "inscription {} script pubkey not valid address",
+            inscription_id,
+          );
+        };
+
+        let seller_address = seller_address
+          .parse::<Address<NetworkUnchecked>>()
+          .unwrap()
+          .require_network(wallet.chain().network())?;
+
+        (
+          seller_address,
+          Amount::from_sat(postage),
+          inscription.satpoint.outpoint,
+        )
+      }
+      (None, Some(outgoing)) => {
+        let (decimal, spaced_rune) = match outgoing {
+          Outgoing::Rune { decimal, rune } => (decimal, rune),
+          _ => bail!("invalid format for --rune (must be `DECIMAL:RUNE`)"),
+        };
+
+        ensure!(
+          wallet.has_rune_index(),
+          "creating runes offer with `offer` requires index created with `--index-runes` flag",
+        );
+
+        wallet
+          .get_rune(spaced_rune.rune)?
+          .with_context(|| format!("rune `{}` has not been etched", spaced_rune.rune))?;
+
+        let Some(utxo) = self.utxo else {
+          bail!("--utxo must be set");
+        };
+
+        ensure!(
+          !wallet.utxos().contains_key(&utxo),
+          "utxo {} already in wallet",
+          utxo
+        );
+
+        ensure! {
+          wallet.output_exists(utxo)?,
+          "utxo {} does not exist",
+          utxo
+        }
+
+        let Some(output_info) = wallet.get_output_info(utxo)? else {
+          bail!("utxo {} does not exist", utxo);
+        };
+
+        let Some(seller_address) = output_info.address else {
+          bail!("utxo {} script pubkey not valid address", utxo);
+        };
+
+        let Some(runes) = output_info.runes else {
+          bail!("utxo {} does not hold any {} runes", utxo, spaced_rune);
+        };
+
+        let Some(pile) = runes.get(&spaced_rune) else {
+          bail!("utxo {} does not hold any {} runes", utxo, spaced_rune);
+        };
+
+        ensure! {
+          pile.amount == decimal.value,
+          "utxo holds unexpected {} balance (expected {}, found {})",
+          spaced_rune,
+          decimal.value,
+          pile.amount
+        }
+
+        ensure! {
+          runes.len() == 1,
+          "utxo {} holds multiple runes",
+          utxo
+        }
+
+        let seller_address = seller_address.require_network(wallet.chain().network())?;
+
+        (seller_address, Amount::from_sat(output_info.value), utxo)
+      }
+      _ => unreachable!("--inscription or --rune must be set, but not both"),
     };
-
-    Ok(Some(Box::new(Output {
-      psbt,
-      seller_address,
-      inscription: self.inscription,
-      rune: self.rune.clone(),
-    })))
-  }
-
-  fn create_inscription_buy_offer(
-    &self,
-    wallet: Wallet,
-    inscription_id: InscriptionId,
-  ) -> Result<(String, Address<NetworkUnchecked>)> {
-    ensure!(
-      !wallet.inscription_info().contains_key(&inscription_id),
-      "inscription {} already in wallet",
-      inscription_id
-    );
-
-    let Some(inscription) = wallet.get_inscription(inscription_id)? else {
-      bail!("inscription {} does not exist", inscription_id);
-    };
-
-    let Some(postage) = inscription.value else {
-      bail!("inscription {} unbound", inscription_id);
-    };
-
-    let Some(seller_address) = inscription.address else {
-      bail!(
-        "inscription {} script pubkey not valid address",
-        inscription_id,
-      );
-    };
-
-    for utxo in &self.utxo {
-      ensure! {
-        inscription.satpoint.outpoint == *utxo,
-        "inscription utxo {} does not match provided utxo {}",
-        inscription.satpoint.outpoint,
-        utxo
-      };
-    }
-
-    let seller_address = seller_address
-      .parse::<Address<NetworkUnchecked>>()
-      .unwrap()
-      .require_network(wallet.chain().network())?;
-
-    let seller_postage = Amount::from_sat(postage);
-
-    let mut buyer_postage = self.postage.unwrap_or(TARGET_POSTAGE);
-
-    if seller_postage > buyer_postage {
-      buyer_postage = seller_postage;
-    }
 
     let tx = Transaction {
       version: Version(2),
       lock_time: LockTime::ZERO,
       input: vec![TxIn {
-        previous_output: inscription.satpoint.outpoint,
+        previous_output: utxo,
         script_sig: ScriptBuf::new(),
         sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
         witness: Witness::new(),
       }],
       output: vec![
         TxOut {
-          value: buyer_postage,
+          value: postage,
           script_pubkey: wallet.get_change_address()?.into(),
         },
         TxOut {
-          value: self.amount + seller_postage,
+          value: self.amount + postage,
           script_pubkey: seller_address.clone().into(),
         },
       ],
     };
 
-    let psbt = self.create_funded_buy_offer(wallet, tx)?;
-
-    Ok((psbt, seller_address.into_unchecked()))
-  }
-
-  fn create_rune_buy_offer(
-    &self,
-    wallet: Wallet,
-    outgoing: Outgoing,
-  ) -> Result<(String, Address<NetworkUnchecked>)> {
-    let (decimal, spaced_rune) = match outgoing {
-      Outgoing::Rune { decimal, rune } => (decimal, rune),
-      _ => bail!("invalid format for --rune (must be `DECIMAL:RUNE`)"),
-    };
-
-    ensure!(
-      wallet.has_rune_index(),
-      "creating runes offer with `offer` requires index created with `--index-runes` flag",
-    );
-
-    let (id, _, _) = wallet
-      .get_rune(spaced_rune.rune)?
-      .with_context(|| format!("rune `{}` has not been etched", spaced_rune.rune))?;
-
-    ensure! {
-      !self.utxo.is_empty(),
-      "--utxo must be set"
-    }
-
-    let mut contains_multiple_runes = false;
-    let mut amount = 0;
-    let mut seller_address = None;
-    let mut seller_postage = Amount::ZERO;
-
-    for utxo in &self.utxo {
-      ensure!(
-        !wallet.utxos().contains_key(utxo),
-        "utxo {} already in wallet",
-        *utxo
-      );
-
-      ensure! {
-        wallet.output_exists(*utxo)?,
-        "utxo {} does not exist",
-        *utxo
-      }
-
-      let Some(output_info) = wallet.get_output_info(*utxo)? else {
-        bail!("utxo {} does not exist", *utxo);
-      };
-
-      let Some(utxo_seller_address) = output_info.address else {
-        bail!("utxo {} script pubkey not valid address", *utxo);
-      };
-
-      let Some(runes) = output_info.runes else {
-        bail!("utxo {} does not hold any runes", *utxo);
-      };
-
-      let Some(pile) = runes.get(&spaced_rune) else {
-        bail!("utxo {} does not hold any {} runes", *utxo, spaced_rune);
-      };
-
-      if runes.len() > 1 {
-        contains_multiple_runes = true;
-      }
-
-      amount += pile.amount;
-
-      if seller_address.is_none() {
-        seller_address = Some(utxo_seller_address);
-      }
-
-      seller_postage += Amount::from_sat(output_info.value);
-    }
-
-    if amount < decimal.value {
-      bail!(
-        "utxo(s) hold less {} than required ({} < {})",
-        spaced_rune,
-        amount,
-        decimal.value,
-      );
-    }
-
-    if amount > decimal.value {
-      bail!(
-        "utxo(s) hold more {} than expected ({} > {})",
-        spaced_rune,
-        amount,
-        decimal.value,
-      );
-    }
-
-    let buyer_postage = self.postage.unwrap_or(TARGET_POSTAGE);
-
-    let seller_address = seller_address
-      .unwrap()
-      .require_network(wallet.chain().network())?;
-
-    let output = if contains_multiple_runes {
-      let runestone = Runestone {
-        edicts: vec![Edict {
-          amount: 0,
-          id,
-          output: 2,
-        }],
-        ..default()
-      };
-
-      vec![
-        TxOut {
-          value: seller_postage,
-          script_pubkey: seller_address.clone().into(),
-        },
-        TxOut {
-          value: self.amount,
-          script_pubkey: seller_address.clone().into(),
-        },
-        TxOut {
-          value: buyer_postage,
-          script_pubkey: wallet.get_change_address()?.into(),
-        },
-        TxOut {
-          value: Amount::ZERO,
-          script_pubkey: runestone.encipher(),
-        },
-      ]
-    } else {
-      vec![
-        TxOut {
-          value: buyer_postage,
-          script_pubkey: wallet.get_change_address()?.into(),
-        },
-        TxOut {
-          value: self.amount + seller_postage,
-          script_pubkey: seller_address.clone().into(),
-        },
-      ]
-    };
-
-    let tx = Transaction {
-      version: Version(2),
-      lock_time: LockTime::ZERO,
-      input: self
-        .utxo
-        .clone()
-        .into_iter()
-        .map(|utxo| TxIn {
-          previous_output: utxo,
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-          witness: Witness::new(),
-        })
-        .collect(),
-      output,
-    };
-
-    let psbt = self.create_funded_buy_offer(wallet, tx)?;
-
-    Ok((psbt, seller_address.into_unchecked()))
-  }
-
-  fn create_funded_buy_offer(&self, wallet: Wallet, tx: Transaction) -> Result<String> {
     wallet.lock_non_cardinal_outputs()?;
 
     let tx = fund_raw_transaction(wallet.bitcoin_client(), self.fee_rate, &tx)?;
@@ -298,6 +181,11 @@ impl Create {
       "PSBT unexpectedly complete after processing with wallet",
     }
 
-    Ok(result.psbt)
+    Ok(Some(Box::new(Output {
+      psbt: result.psbt,
+      seller_address: seller_address.into_unchecked(),
+      inscription: self.inscription,
+      rune: self.rune.clone(),
+    })))
   }
 }

--- a/src/subcommand/wallet/offer/create.rs
+++ b/src/subcommand/wallet/offer/create.rs
@@ -16,7 +16,7 @@ pub struct Output {
 pub(crate) struct Create {
   #[arg(long, help = "<INSCRIPTION> to make offer for.")]
   inscription: Option<InscriptionId>,
-  #[arg(long, help = "<DECIMAL:RUNE> to make offer for.")]
+  #[arg(long, help = "<DECIMAL:RUNE> to make offer for.", requires = "utxo")]
   rune: Option<Outgoing>,
   #[arg(long, help = "<AMOUNT> to offer.")]
   amount: Amount,
@@ -86,9 +86,9 @@ impl Create {
           .get_rune(spaced_rune.rune)?
           .with_context(|| format!("rune `{}` has not been etched", spaced_rune.rune))?;
 
-        let Some(utxo) = self.utxo else {
-          bail!("--utxo must be set");
-        };
+        assert!(self.utxo.is_some());
+
+        let utxo = self.utxo.unwrap();
 
         ensure!(
           !wallet.utxos().contains_key(&utxo),

--- a/src/subcommand/wallet/offer/create.rs
+++ b/src/subcommand/wallet/offer/create.rs
@@ -130,7 +130,7 @@ impl Create {
 
     ensure!(
       wallet.has_rune_index(),
-      "creating runes offer with `buy-offer` requires index created with `--index-runes` flag",
+      "creating runes offer with `offer` requires index created with `--index-runes` flag",
     );
 
     let (id, _, _) = wallet

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -216,6 +216,27 @@ impl Wallet {
     Ok(inscription)
   }
 
+  pub(crate) fn get_output_info(&self, output: OutPoint) -> Result<Option<api::Output>> {
+    let output_info = self
+      .ord_client
+      .get(self.rpc_url.join(&format!("/output/{output}")).unwrap())
+      .send()?
+      .json()?;
+
+    Ok(output_info)
+  }
+
+  pub(crate) fn output_exists(&self, output: OutPoint) -> Result<bool> {
+    Ok(
+      !self
+        .ord_client
+        .get(self.rpc_url.join(&format!("/output/{output}")).unwrap())
+        .send()?
+        .status()
+        .is_client_error(),
+    )
+  }
+
   pub(crate) fn inscription_exists(&self, inscription_id: InscriptionId) -> Result<bool> {
     Ok(
       !self

--- a/tests/wallet/offer/accept.rs
+++ b/tests/wallet/offer/accept.rs
@@ -1286,7 +1286,7 @@ fn error_must_include_either_inscription_or_rune() {
 
   create_wallet(&core, &ord);
 
-  CommandBuilder::new(format!("wallet offer accept --amount 1btc --psbt ="))
+  CommandBuilder::new("wallet offer accept --amount 1btc --psbt =")
     .core(&core)
     .ord(&ord)
     .stderr_regex(

--- a/tests/wallet/offer/accept.rs
+++ b/tests/wallet/offer/accept.rs
@@ -421,6 +421,368 @@ fn accepted_rune_offer_works_when_multiple_runes_present() {
   );
 }
 
+#[test]
+fn accepted_rune_offer_works_when_multiple_utxos_present() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune = Rune(RUNE);
+  etch(&core, &ord, rune);
+
+  core.mine_blocks(1);
+
+  let seller_address2 = core.state().new_address(false);
+
+  let send = CommandBuilder::new(format!(
+    "
+      --regtest
+      wallet
+      send
+      --fee-rate 1
+      {} 500:{}
+    ",
+    seller_address2,
+    Rune(RUNE),
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let seller_address = Address::from_script(
+    &core.tx_by_id(send.txid).output[1].script_pubkey,
+    Network::Regtest,
+  )
+  .unwrap();
+
+  core.state().remove_wallet_address(seller_address.clone());
+  core.state().remove_wallet_address(seller_address2.clone());
+
+  let utxo0 = OutPoint {
+    txid: send.txid,
+    vout: 1,
+  };
+
+  let utxo1 = OutPoint {
+    txid: send.txid,
+    vout: 2,
+  };
+
+  let buyer_postage = 8_000;
+  let seller_postage = 20_000;
+
+  let pre_balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  let create = CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune {}:{} --amount 1btc --fee-rate 0 --utxo {} --utxo {} --postage {}sats",
+    1000,
+    Rune(RUNE),
+    utxo0,
+    utxo1,
+    buyer_postage
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  assert_eq!(
+    create
+      .seller_address
+      .clone()
+      .require_network(Network::Regtest)
+      .unwrap(),
+    seller_address,
+  );
+
+  let mut buyer_addresses = core.state().clear_wallet_addresses();
+  buyer_addresses.remove(&seller_address);
+
+  core.state().add_wallet_address(seller_address.clone());
+  core.state().add_wallet_address(seller_address2.clone());
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer accept --rune {}:{} --amount 1btc --psbt {} --dry-run",
+    1000,
+    Rune(RUNE),
+    create.psbt
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Accept>();
+
+  core.mine_blocks(1);
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(balance.runic, Some(seller_postage));
+  assert_eq!(balance.cardinal, 50 * COIN_VALUE);
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer accept --rune {}:{} --amount 1btc --psbt {}",
+    1000,
+    Rune(RUNE),
+    create.psbt,
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Accept>();
+
+  core.mine_blocks(1);
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(balance.runic, Some(0));
+  assert_eq!(
+    balance.cardinal,
+    2 * 50 * COIN_VALUE + COIN_VALUE + seller_postage
+  );
+
+  core.state().remove_wallet_address(seller_address.clone());
+
+  for address in buyer_addresses {
+    core.state().add_wallet_address(address);
+  }
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(
+    balance.runes,
+    Some(
+      vec![(
+        SpacedRune {
+          rune: Rune(RUNE),
+          spacers: 0
+        },
+        Decimal {
+          value: 1000,
+          scale: 0,
+        }
+      )]
+      .into_iter()
+      .collect()
+    )
+  );
+
+  assert_eq!(balance.runic, Some(buyer_postage));
+  assert_eq!(
+    balance.cardinal,
+    pre_balance.cardinal + 2 * 50 * COIN_VALUE - buyer_postage - COIN_VALUE
+  );
+}
+
+#[test]
+fn accepted_rune_offer_works_when_multiple_runes_present_in_multiple_utxos() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune = Rune(RUNE);
+  etch(&core, &ord, rune);
+  let b = etch(&core, &ord, Rune(RUNE + 1));
+
+  core.mine_blocks(1);
+
+  let seller_address = core.state().new_address(false);
+
+  let send = CommandBuilder::new(format!(
+    "
+      --regtest
+      wallet
+      send
+      --fee-rate 1
+      {} 500:{}
+    ",
+    seller_address,
+    Rune(RUNE),
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let (a_block, a_tx) = core.tx_index(send.txid);
+  let (b_block, b_tx) = core.tx_index(b.output.reveal);
+
+  let seller_address2 = CommandBuilder::new("--regtest wallet receive")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<ord::subcommand::wallet::receive::Output>()
+    .addresses
+    .into_iter()
+    .next()
+    .unwrap()
+    .require_network(Network::Regtest)
+    .unwrap();
+
+  let merge = core.broadcast_tx(TransactionTemplate {
+    inputs: &[(a_block, a_tx, 1, default()), (b_block, b_tx, 1, default())],
+    recipient: Some(seller_address2.clone()),
+    ..default()
+  });
+
+  core.mine_blocks(1);
+
+  core.state().remove_wallet_address(seller_address.clone());
+  core.state().remove_wallet_address(seller_address2.clone());
+
+  let utxo0 = OutPoint {
+    txid: send.txid,
+    vout: 2,
+  };
+
+  let utxo1 = OutPoint {
+    txid: merge,
+    vout: 0,
+  };
+
+  let pre_balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  let create = CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune {}:{} --amount 1btc --fee-rate 0 --utxo {} --utxo {}",
+    1000,
+    Rune(RUNE),
+    utxo0,
+    utxo1,
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  assert_eq!(
+    create
+      .seller_address
+      .clone()
+      .require_network(Network::Regtest)
+      .unwrap(),
+    seller_address,
+  );
+
+  let mut buyer_addresses = core.state().clear_wallet_addresses();
+  buyer_addresses.remove(&seller_address);
+
+  core.state().add_wallet_address(seller_address.clone());
+  core.state().add_wallet_address(seller_address2.clone());
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer accept --rune {}:{} --amount 1btc --psbt {} --dry-run",
+    1000,
+    Rune(RUNE),
+    create.psbt
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Accept>();
+
+  core.mine_blocks(1);
+
+  let seller_postage = 30_000;
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(balance.runic, Some(seller_postage));
+  assert_eq!(balance.cardinal, 50 * COIN_VALUE);
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer accept --rune {}:{} --amount 1btc --psbt {}",
+    1000,
+    Rune(RUNE),
+    create.psbt,
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Accept>();
+
+  core.mine_blocks(1);
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(balance.runic, Some(seller_postage));
+  assert_eq!(balance.cardinal, 2 * 50 * COIN_VALUE + COIN_VALUE);
+
+  assert_eq!(
+    balance.runes,
+    Some(
+      vec![(
+        SpacedRune {
+          rune: Rune(RUNE + 1),
+          spacers: 0
+        },
+        Decimal {
+          value: 1000,
+          scale: 0,
+        }
+      )]
+      .into_iter()
+      .collect()
+    )
+  );
+
+  core.state().remove_wallet_address(seller_address.clone());
+
+  for address in buyer_addresses {
+    core.state().add_wallet_address(address);
+  }
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(
+    balance.runes,
+    Some(
+      vec![(
+        SpacedRune {
+          rune: Rune(RUNE),
+          spacers: 0
+        },
+        Decimal {
+          value: 1000,
+          scale: 0,
+        }
+      )]
+      .into_iter()
+      .collect()
+    )
+  );
+
+  let buyer_postage = 10_000;
+
+  assert_eq!(balance.runic, Some(buyer_postage));
+  assert_eq!(
+    balance.cardinal,
+    pre_balance.cardinal + 2 * 50 * COIN_VALUE - buyer_postage - COIN_VALUE
+  );
+}
+
 #[track_caller]
 fn error_case(
   core: &mockcore::Handle,
@@ -492,7 +854,7 @@ fn psbt_may_not_contain_no_inputs_owned_by_wallet() {
 }
 
 #[test]
-fn psbt_may_not_contain_more_than_one_input_owned_by_wallet() {
+fn psbt_may_not_contain_more_than_one_input_owned_by_wallet_if_inscription_offer() {
   let core = mockcore::spawn();
 
   let ord = TestServer::spawn_with_server_args(&core, &[], &[]);
@@ -531,14 +893,6 @@ fn psbt_may_not_contain_more_than_one_input_owned_by_wallet() {
     &ord,
     tx.clone(),
     true,
-    "error: PSBT contains 2 inputs owned by wallet\n",
-  );
-
-  error_case(
-    &core,
-    &ord,
-    tx.clone(),
-    false,
     "error: PSBT contains 2 inputs owned by wallet\n",
   );
 }
@@ -1242,8 +1596,8 @@ fn outgoing_contains_unexpected_rune_balance_in_rune_offer() {
   .ord(&ord)
   .expected_exit_code(1)
   .expected_stderr(format!(
-    "error: unexpected rune {} balance at outgoing input {} ({} vs. {})\n",
-    rune, outpoint, 500, 250
+    "error: unexpected rune {} balance at outgoing input(s) ({} vs. {})\n",
+    rune, 500, 250
   ))
   .run_and_extract_stdout();
 }

--- a/tests/wallet/offer/accept.rs
+++ b/tests/wallet/offer/accept.rs
@@ -4,7 +4,7 @@ type Accept = ord::subcommand::wallet::offer::accept::Output;
 type Create = ord::subcommand::wallet::offer::create::Output;
 
 #[test]
-fn accepted_offer_works() {
+fn accepted_inscription_offer_works() {
   let core = mockcore::spawn();
 
   let ord = TestServer::spawn_with_server_args(&core, &[], &[]);
@@ -107,8 +107,167 @@ fn accepted_offer_works() {
   );
 }
 
+#[test]
+fn accepted_rune_offer_works() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE));
+
+  let seller_postage = 9000;
+
+  let send = CommandBuilder::new(format!(
+    "
+      --regtest
+      wallet
+      send
+      --fee-rate 1
+      --postage {}sats
+      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 750:{}
+    ",
+    seller_postage,
+    Rune(RUNE),
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let seller_address = Address::from_script(
+    &core.tx_by_id(send.txid).output[1].script_pubkey,
+    Network::Regtest,
+  )
+  .unwrap();
+
+  core.state().remove_wallet_address(seller_address.clone());
+
+  let outpoint = OutPoint {
+    txid: send.txid,
+    vout: 1,
+  };
+
+  let pre_balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  let create = CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune {}:{} --amount 1btc --fee-rate 0 --utxo {}",
+    250,
+    Rune(RUNE),
+    outpoint
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  assert_eq!(
+    create
+      .seller_address
+      .clone()
+      .require_network(Network::Regtest)
+      .unwrap(),
+    seller_address,
+  );
+
+  let mut buyer_addresses = core.state().clear_wallet_addresses();
+  buyer_addresses.remove(&seller_address);
+
+  core.state().add_wallet_address(seller_address.clone());
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer accept --rune {}:{} --amount 1btc --psbt {} --dry-run",
+    250,
+    Rune(RUNE),
+    create.psbt
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Accept>();
+
+  core.mine_blocks(1);
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(balance.runic, Some(seller_postage));
+  assert_eq!(balance.cardinal, 50 * COIN_VALUE);
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer accept --rune {}:{} --amount 1btc --psbt {}",
+    250,
+    Rune(RUNE),
+    create.psbt,
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Accept>();
+
+  core.mine_blocks(1);
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(balance.runic, Some(0));
+  assert_eq!(
+    balance.cardinal,
+    2 * 50 * COIN_VALUE + COIN_VALUE + seller_postage
+  );
+
+  core.state().remove_wallet_address(seller_address.clone());
+
+  for address in buyer_addresses {
+    core.state().add_wallet_address(address);
+  }
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(
+    balance.runes,
+    Some(
+      vec![(
+        SpacedRune {
+          rune: Rune(RUNE),
+          spacers: 0
+        },
+        Decimal {
+          value: 250,
+          scale: 0,
+        }
+      )]
+      .into_iter()
+      .collect()
+    )
+  );
+
+  let buyer_postage = 10_000;
+
+  assert_eq!(balance.runic, Some(buyer_postage));
+  assert_eq!(
+    balance.cardinal,
+    pre_balance.cardinal + 2 * 50 * COIN_VALUE - buyer_postage - COIN_VALUE
+  );
+}
+
 #[track_caller]
-fn error_case(core: &mockcore::Handle, ord: &TestServer, tx: Transaction, message: &str) {
+fn error_case(
+  core: &mockcore::Handle,
+  ord: &TestServer,
+  tx: Transaction,
+  is_inscription: bool,
+  message: &str,
+) {
   let psbt = Psbt::from_unsigned_tx(tx).unwrap();
 
   let base64 = base64_encode(&psbt.serialize());
@@ -117,8 +276,16 @@ fn error_case(core: &mockcore::Handle, ord: &TestServer, tx: Transaction, messag
     "wallet",
     "offer",
     "accept",
-    "--inscription",
-    "6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0",
+    if is_inscription {
+      "--inscription"
+    } else {
+      "--rune"
+    },
+    if is_inscription {
+      "6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0"
+    } else {
+      "1000:FOO"
+    },
     "--amount",
     "1btc",
     "--psbt",
@@ -139,15 +306,26 @@ fn psbt_may_not_contain_no_inputs_owned_by_wallet() {
 
   create_wallet(&core, &ord);
 
+  let tx = Transaction {
+    version: Version(2),
+    lock_time: LockTime::ZERO,
+    input: Vec::new(),
+    output: Vec::new(),
+  };
+
   error_case(
     &core,
     &ord,
-    Transaction {
-      version: Version(2),
-      lock_time: LockTime::ZERO,
-      input: Vec::new(),
-      output: Vec::new(),
-    },
+    tx.clone(),
+    true,
+    "error: PSBT contains no inputs owned by wallet\n",
+  );
+
+  error_case(
+    &core,
+    &ord,
+    tx.clone(),
+    false,
     "error: PSBT contains no inputs owned by wallet\n",
   );
 }
@@ -167,28 +345,39 @@ fn psbt_may_not_contain_more_than_one_input_owned_by_wallet() {
     .ord(&ord)
     .run_and_deserialize_output::<Vec<ord::subcommand::wallet::outputs::Output>>();
 
+  let tx = Transaction {
+    version: Version(2),
+    lock_time: LockTime::ZERO,
+    input: vec![
+      TxIn {
+        previous_output: outputs[0].output,
+        script_sig: ScriptBuf::new(),
+        sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+        witness: Witness::new(),
+      },
+      TxIn {
+        previous_output: outputs[1].output,
+        script_sig: ScriptBuf::new(),
+        sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+        witness: Witness::new(),
+      },
+    ],
+    output: Vec::new(),
+  };
+
   error_case(
     &core,
     &ord,
-    Transaction {
-      version: Version(2),
-      lock_time: LockTime::ZERO,
-      input: vec![
-        TxIn {
-          previous_output: outputs[0].output,
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-          witness: Witness::new(),
-        },
-        TxIn {
-          previous_output: outputs[1].output,
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-          witness: Witness::new(),
-        },
-      ],
-      output: Vec::new(),
-    },
+    tx.clone(),
+    true,
+    "error: PSBT contains 2 inputs owned by wallet\n",
+  );
+
+  error_case(
+    &core,
+    &ord,
+    tx.clone(),
+    false,
     "error: PSBT contains 2 inputs owned by wallet\n",
   );
 }
@@ -217,6 +406,23 @@ fn error_on_base64_psbt_decode() {
   .expected_exit_code(1)
   .stderr_regex("error: failed to base64 decode PSBT\n.*")
   .run_and_extract_stdout();
+
+  CommandBuilder::new([
+    "wallet",
+    "offer",
+    "accept",
+    "--rune",
+    &format!("1000:{}", Rune(RUNE)),
+    "--amount",
+    "1btc",
+    "--psbt",
+    "=",
+  ])
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .stderr_regex("error: failed to base64 decode PSBT\n.*")
+  .run_and_extract_stdout();
 }
 
 #[test]
@@ -233,6 +439,23 @@ fn error_on_psbt_deserialize() {
     "accept",
     "--inscription",
     "6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0",
+    "--amount",
+    "1btc",
+    "--psbt",
+    "",
+  ])
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .stderr_regex("error: failed to deserialize PSBT\n.*")
+  .run_and_extract_stdout();
+
+  CommandBuilder::new([
+    "wallet",
+    "offer",
+    "accept",
+    "--rune",
+    &format!("1000:{}", Rune(RUNE)),
     "--amount",
     "1btc",
     "--psbt",
@@ -274,6 +497,7 @@ fn outgoing_may_not_contain_no_inscriptions() {
       }],
       output: Vec::new(),
     },
+    true,
     "error: outgoing input contains no inscriptions\n",
   );
 }
@@ -304,6 +528,7 @@ fn expected_outgoing_inscription() {
       }],
       output: Vec::new(),
     },
+    true,
     &format!("error: unexpected outgoing inscription {inscription}\n"),
   );
 }
@@ -405,6 +630,7 @@ inscriptions:
     &core,
     &ord,
     tx,
+    true,
     &format!("error: outgoing input {outpoint} contains 2 inscriptions\n"),
   );
 }
@@ -634,5 +860,526 @@ fn seller_input_must_not_be_signed() {
     "error: seller input `{}` is signed: seller input must not be signed\n",
     psbt.unsigned_tx.input[0].previous_output,
   ))
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn must_index_runes_if_rune_offer() {
+  let core = mockcore::spawn();
+
+  let ord = TestServer::spawn_with_server_args(&core, &[], &[]);
+
+  create_wallet(&core, &ord);
+
+  core.mine_blocks(1);
+
+  let outputs = CommandBuilder::new("wallet outputs")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Vec<ord::subcommand::wallet::outputs::Output>>();
+
+  error_case(
+    &core,
+    &ord,
+    Transaction {
+      version: Version(2),
+      lock_time: LockTime::ZERO,
+      input: vec![TxIn {
+        previous_output: outputs[0].output,
+        script_sig: ScriptBuf::new(),
+        sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+        witness: Witness::new(),
+      }],
+      output: Vec::new(),
+    },
+    false,
+    "error: accepting rune offer with `offer` requires index created with `--index-runes` flag\n",
+  );
+}
+
+#[test]
+fn rune_must_be_etched_in_rune_offer() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  core.mine_blocks(1);
+
+  let outputs = CommandBuilder::new("--regtest wallet outputs")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Vec<ord::subcommand::wallet::outputs::Output>>();
+
+  let psbt = Psbt::from_unsigned_tx(Transaction {
+    version: Version(2),
+    lock_time: LockTime::ZERO,
+    input: vec![TxIn {
+      previous_output: outputs[0].output,
+      script_sig: ScriptBuf::new(),
+      sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+      witness: Witness::new(),
+    }],
+    output: Vec::new(),
+  })
+  .unwrap();
+
+  let base64 = base64_encode(&psbt.serialize());
+
+  CommandBuilder::new([
+    "--regtest",
+    "wallet",
+    "offer",
+    "accept",
+    "--rune",
+    &format!("1000:{}", Rune(RUNE)),
+    "--amount",
+    "1btc",
+    "--psbt",
+    &base64,
+  ])
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .expected_stderr(format!(
+    "error: rune `{}` has not been etched\n",
+    Rune(RUNE)
+  ))
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn outgoing_must_contain_rune_if_rune_offer() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune = Rune(RUNE);
+  etch(&core, &ord, rune);
+
+  let send = CommandBuilder::new(
+    "
+      --regtest
+      --index-runes
+      wallet
+      send
+      --fee-rate 1
+      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 1000sat
+    ",
+  )
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let outpoint = OutPoint {
+    txid: send.txid,
+    vout: 1,
+  };
+
+  let psbt = Psbt::from_unsigned_tx(Transaction {
+    version: Version(2),
+    lock_time: LockTime::ZERO,
+    input: vec![TxIn {
+      previous_output: outpoint,
+      script_sig: ScriptBuf::new(),
+      sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+      witness: Witness::new(),
+    }],
+    output: Vec::new(),
+  })
+  .unwrap();
+
+  let base64 = base64_encode(&psbt.serialize());
+
+  CommandBuilder::new([
+    "--regtest",
+    "wallet",
+    "offer",
+    "accept",
+    "--rune",
+    &format!("250:{}", rune),
+    "--amount",
+    "1btc",
+    "--psbt",
+    &base64,
+  ])
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .expected_stderr(format!(
+    "error: outgoing input {outpoint} does not contain rune {rune}\n"
+  ))
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn outgoing_contains_unexpected_rune_balance_in_rune_offer() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune = Rune(RUNE);
+  etch(&core, &ord, rune);
+
+  let send = CommandBuilder::new(format!(
+    "
+      --regtest
+      --index-runes
+      wallet
+      send
+      --fee-rate 1
+      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 500:{}
+    ",
+    rune
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let outpoint = OutPoint {
+    txid: send.txid,
+    vout: 1,
+  };
+
+  let psbt = Psbt::from_unsigned_tx(Transaction {
+    version: Version(2),
+    lock_time: LockTime::ZERO,
+    input: vec![TxIn {
+      previous_output: outpoint,
+      script_sig: ScriptBuf::new(),
+      sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+      witness: Witness::new(),
+    }],
+    output: Vec::new(),
+  })
+  .unwrap();
+
+  let base64 = base64_encode(&psbt.serialize());
+
+  CommandBuilder::new([
+    "--regtest",
+    "wallet",
+    "offer",
+    "accept",
+    "--rune",
+    &format!("250:{}", rune),
+    "--amount",
+    "1btc",
+    "--psbt",
+    &base64,
+  ])
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .expected_stderr(format!(
+    "error: unexpected rune {} balance at outgoing input {} ({} vs. {})\n",
+    rune, outpoint, 500, 250
+  ))
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn outgoing_contains_inscription_in_rune_offer() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune = Rune(RUNE);
+  let a = etch(&core, &ord, rune);
+
+  let (block, tx) = core.tx_index(a.output.reveal);
+
+  core.mine_blocks(1);
+
+  let address = CommandBuilder::new("--regtest wallet receive")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<ord::subcommand::wallet::receive::Output>()
+    .addresses
+    .into_iter()
+    .next()
+    .unwrap();
+
+  let merge = core.broadcast_tx(TransactionTemplate {
+    inputs: &[(block, tx, 0, default()), (block, tx, 1, default())],
+    recipient: Some(address.require_network(Network::Regtest).unwrap()),
+    ..default()
+  });
+
+  let outpoint = OutPoint {
+    txid: merge,
+    vout: 0,
+  };
+
+  core.mine_blocks(1);
+
+  let psbt = Psbt::from_unsigned_tx(Transaction {
+    version: Version(2),
+    lock_time: LockTime::ZERO,
+    input: vec![TxIn {
+      previous_output: outpoint,
+      script_sig: ScriptBuf::new(),
+      sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+      witness: Witness::new(),
+    }],
+    output: Vec::new(),
+  })
+  .unwrap();
+
+  let base64 = base64_encode(&psbt.serialize());
+
+  CommandBuilder::new([
+    "--regtest",
+    "wallet",
+    "offer",
+    "accept",
+    "--rune",
+    &format!("1000:{}", rune),
+    "--amount",
+    "1btc",
+    "--psbt",
+    &base64,
+  ])
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .expected_stderr(format!(
+    "error: outgoing input {outpoint} contains 1 inscription(s)\n"
+  ))
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn outgoing_contains_multiple_runes_in_rune_offer() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune0 = Rune(RUNE);
+  let rune1 = Rune(RUNE + 1);
+  let a = etch(&core, &ord, rune0);
+  let b = etch(&core, &ord, rune1);
+
+  let (block0, tx0) = core.tx_index(a.output.reveal);
+  let (block1, tx1) = core.tx_index(b.output.reveal);
+
+  core.mine_blocks(1);
+
+  let address = CommandBuilder::new("--regtest wallet receive")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<ord::subcommand::wallet::receive::Output>()
+    .addresses
+    .into_iter()
+    .next()
+    .unwrap();
+
+  let merge = core.broadcast_tx(TransactionTemplate {
+    inputs: &[(block0, tx0, 1, default()), (block1, tx1, 1, default())],
+    recipient: Some(address.require_network(Network::Regtest).unwrap()),
+    ..default()
+  });
+
+  let outpoint = OutPoint {
+    txid: merge,
+    vout: 0,
+  };
+
+  core.mine_blocks(1);
+
+  let psbt = Psbt::from_unsigned_tx(Transaction {
+    version: Version(2),
+    lock_time: LockTime::ZERO,
+    input: vec![TxIn {
+      previous_output: outpoint,
+      script_sig: ScriptBuf::new(),
+      sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+      witness: Witness::new(),
+    }],
+    output: Vec::new(),
+  })
+  .unwrap();
+
+  let base64 = base64_encode(&psbt.serialize());
+
+  CommandBuilder::new([
+    "--regtest",
+    "wallet",
+    "offer",
+    "accept",
+    "--rune",
+    &format!("1000:{}", rune0),
+    "--amount",
+    "1btc",
+    "--psbt",
+    &base64,
+  ])
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .expected_stderr(format!(
+    "error: outgoing input {outpoint} contains multiple runes\n"
+  ))
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn error_must_include_either_inscription_or_rune() {
+  let core = mockcore::spawn();
+
+  let ord = TestServer::spawn_with_server_args(&core, &[], &[]);
+
+  create_wallet(&core, &ord);
+
+  let postage = 9000;
+
+  let (inscription, txid) = inscribe_with_options(&core, &ord, Some(postage), 0);
+
+  let inscription_address = Address::from_script(
+    &core.tx_by_id(txid).output[0].script_pubkey,
+    Network::Bitcoin,
+  )
+  .unwrap();
+
+  core
+    .state()
+    .remove_wallet_address(inscription_address.clone());
+
+  let create = CommandBuilder::new(format!(
+    "wallet offer create --inscription {inscription} --amount 1btc --fee-rate 0"
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  let mut psbt = Psbt::deserialize(&base64_decode(&create.psbt).unwrap()).unwrap();
+
+  psbt.inputs[0].final_script_witness = Some(default());
+
+  let mut buyer_addresses = core.state().clear_wallet_addresses();
+  buyer_addresses.remove(&inscription_address);
+
+  core.state().add_wallet_address(inscription_address.clone());
+
+  let base64 = base64_encode(&psbt.serialize());
+
+  CommandBuilder::new(format!("wallet offer accept --amount 1btc --psbt {base64}"))
+    .core(&core)
+    .ord(&ord)
+    .expected_stderr("error: must include either --inscription or --rune\n")
+    .expected_exit_code(1)
+    .run_and_extract_stdout();
+}
+
+#[test]
+fn error_cannot_include_both_inscription_and_rune() {
+  let core = mockcore::spawn();
+
+  let ord = TestServer::spawn_with_server_args(&core, &[], &[]);
+
+  create_wallet(&core, &ord);
+
+  let postage = 9000;
+
+  let (inscription, txid) = inscribe_with_options(&core, &ord, Some(postage), 0);
+
+  let inscription_address = Address::from_script(
+    &core.tx_by_id(txid).output[0].script_pubkey,
+    Network::Bitcoin,
+  )
+  .unwrap();
+
+  core
+    .state()
+    .remove_wallet_address(inscription_address.clone());
+
+  let create = CommandBuilder::new(format!(
+    "wallet offer create --inscription {inscription} --amount 1btc --fee-rate 0"
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  let mut psbt = Psbt::deserialize(&base64_decode(&create.psbt).unwrap()).unwrap();
+
+  psbt.inputs[0].final_script_witness = Some(default());
+
+  let mut buyer_addresses = core.state().clear_wallet_addresses();
+  buyer_addresses.remove(&inscription_address);
+
+  core.state().add_wallet_address(inscription_address.clone());
+
+  let base64 = base64_encode(&psbt.serialize());
+
+  CommandBuilder::new(format!(
+    "wallet offer accept --inscription {inscription} --rune 500:FOO --amount 1btc --psbt {base64}"
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr("error: cannot include both --inscription and --rune\n")
+  .expected_exit_code(1)
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn error_rune_not_properly_formatted() {
+  let core = mockcore::spawn();
+
+  let ord = TestServer::spawn_with_server_args(&core, &[], &[]);
+
+  create_wallet(&core, &ord);
+
+  let postage = 9000;
+
+  let (inscription, txid) = inscribe_with_options(&core, &ord, Some(postage), 0);
+
+  let inscription_address = Address::from_script(
+    &core.tx_by_id(txid).output[0].script_pubkey,
+    Network::Bitcoin,
+  )
+  .unwrap();
+
+  core
+    .state()
+    .remove_wallet_address(inscription_address.clone());
+
+  let create = CommandBuilder::new(format!(
+    "wallet offer create --inscription {inscription} --amount 1btc --fee-rate 0"
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  let mut psbt = Psbt::deserialize(&base64_decode(&create.psbt).unwrap()).unwrap();
+
+  psbt.inputs[0].final_script_witness = Some(default());
+
+  let mut buyer_addresses = core.state().clear_wallet_addresses();
+  buyer_addresses.remove(&inscription_address);
+
+  core.state().add_wallet_address(inscription_address.clone());
+
+  let base64 = base64_encode(&psbt.serialize());
+
+  CommandBuilder::new(format!(
+    "wallet offer accept --rune {inscription} --amount 1btc --psbt {base64}"
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr("error: invalid format for --rune (must be `DECIMAL:RUNE`)\n")
+  .expected_exit_code(1)
   .run_and_extract_stdout();
 }

--- a/tests/wallet/offer/accept.rs
+++ b/tests/wallet/offer/accept.rs
@@ -11,9 +11,9 @@ fn accepted_offer_works() {
 
   create_wallet(&core, &ord);
 
-  let postage = 9000;
+  let seller_postage = 9000;
 
-  let (inscription, txid) = inscribe_with_options(&core, &ord, Some(postage), 0);
+  let (inscription, txid) = inscribe_with_options(&core, &ord, Some(seller_postage), 0);
 
   let inscription_address = Address::from_script(
     &core.tx_by_id(txid).output[0].script_pubkey,
@@ -31,6 +31,8 @@ fn accepted_offer_works() {
   .core(&core)
   .ord(&ord)
   .run_and_deserialize_output::<Create>();
+
+  let buyer_postage = 10_000;
 
   let mut buyer_addresses = core.state().clear_wallet_addresses();
   buyer_addresses.remove(&inscription_address);
@@ -52,7 +54,7 @@ fn accepted_offer_works() {
     .ord(&ord)
     .run_and_deserialize_output::<Balance>();
 
-  assert_eq!(balance.ordinal, postage);
+  assert_eq!(balance.ordinal, seller_postage);
   assert_eq!(balance.cardinal, 50 * COIN_VALUE);
 
   CommandBuilder::new(format!(
@@ -71,7 +73,10 @@ fn accepted_offer_works() {
     .run_and_deserialize_output::<Balance>();
 
   assert_eq!(balance.ordinal, 0);
-  assert_eq!(balance.cardinal, 2 * 50 * COIN_VALUE + COIN_VALUE + postage);
+  assert_eq!(
+    balance.cardinal,
+    2 * 50 * COIN_VALUE + COIN_VALUE + seller_postage
+  );
 
   core
     .state()
@@ -95,10 +100,10 @@ fn accepted_offer_works() {
     .ord(&ord)
     .run_and_deserialize_output::<Balance>();
 
-  assert_eq!(balance.ordinal, postage);
+  assert_eq!(balance.ordinal, buyer_postage);
   assert_eq!(
     balance.cardinal,
-    4 * 50 * COIN_VALUE - postage * 2 - COIN_VALUE
+    4 * 50 * COIN_VALUE - buyer_postage - seller_postage - COIN_VALUE
   );
 }
 

--- a/tests/wallet/offer/accept.rs
+++ b/tests/wallet/offer/accept.rs
@@ -260,6 +260,167 @@ fn accepted_rune_offer_works() {
   );
 }
 
+#[test]
+fn accepted_rune_offer_works_when_multiple_runes_present() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune = Rune(RUNE);
+  let a = etch(&core, &ord, rune);
+  let b = etch(&core, &ord, Rune(RUNE + 1));
+
+  let (a_block, a_tx) = core.tx_index(a.output.reveal);
+  let (b_block, b_tx) = core.tx_index(b.output.reveal);
+
+  core.mine_blocks(1);
+
+  let seller_address = core.state().new_address(false);
+
+  let merge = core.broadcast_tx(TransactionTemplate {
+    inputs: &[(a_block, a_tx, 1, default()), (b_block, b_tx, 1, default())],
+    recipient: Some(seller_address.clone()),
+    ..default()
+  });
+
+  core.mine_blocks(1);
+
+  core.state().remove_wallet_address(seller_address.clone());
+
+  let outpoint = OutPoint {
+    txid: merge,
+    vout: 0,
+  };
+
+  let pre_balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  let create = CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune {}:{} --amount 1btc --fee-rate 0 --utxo {}",
+    1000,
+    Rune(RUNE),
+    outpoint
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  assert_eq!(
+    create
+      .seller_address
+      .clone()
+      .require_network(Network::Regtest)
+      .unwrap(),
+    seller_address,
+  );
+
+  let mut buyer_addresses = core.state().clear_wallet_addresses();
+  buyer_addresses.remove(&seller_address);
+
+  core.state().add_wallet_address(seller_address.clone());
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer accept --rune {}:{} --amount 1btc --psbt {} --dry-run",
+    1000,
+    Rune(RUNE),
+    create.psbt
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Accept>();
+
+  core.mine_blocks(1);
+
+  let seller_postage = 20_000;
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(balance.runic, Some(seller_postage));
+  assert_eq!(balance.cardinal, 50 * COIN_VALUE);
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer accept --rune {}:{} --amount 1btc --psbt {}",
+    1000,
+    Rune(RUNE),
+    create.psbt,
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Accept>();
+
+  core.mine_blocks(1);
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(balance.runic, Some(seller_postage));
+  assert_eq!(balance.cardinal, 2 * 50 * COIN_VALUE + COIN_VALUE);
+
+  assert_eq!(
+    balance.runes,
+    Some(
+      vec![(
+        SpacedRune {
+          rune: Rune(RUNE + 1),
+          spacers: 0
+        },
+        Decimal {
+          value: 1000,
+          scale: 0,
+        }
+      )]
+      .into_iter()
+      .collect()
+    )
+  );
+
+  core.state().remove_wallet_address(seller_address.clone());
+
+  for address in buyer_addresses {
+    core.state().add_wallet_address(address);
+  }
+
+  let balance = CommandBuilder::new("--regtest wallet balance")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Balance>();
+
+  assert_eq!(
+    balance.runes,
+    Some(
+      vec![(
+        SpacedRune {
+          rune: Rune(RUNE),
+          spacers: 0
+        },
+        Decimal {
+          value: 1000,
+          scale: 0,
+        }
+      )]
+      .into_iter()
+      .collect()
+    )
+  );
+
+  let buyer_postage = 10_000;
+
+  assert_eq!(balance.runic, Some(buyer_postage));
+  assert_eq!(
+    balance.cardinal,
+    pre_balance.cardinal + 2 * 50 * COIN_VALUE - buyer_postage - COIN_VALUE
+  );
+}
+
 #[track_caller]
 fn error_case(
   core: &mockcore::Handle,
@@ -1161,7 +1322,7 @@ fn outgoing_contains_inscription_in_rune_offer() {
 }
 
 #[test]
-fn outgoing_contains_multiple_runes_in_rune_offer() {
+fn error_missing_runestone_when_utxo_contains_multiple_runes() {
   let core = mockcore::builder().network(Network::Regtest).build();
 
   let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
@@ -1230,9 +1391,234 @@ fn outgoing_contains_multiple_runes_in_rune_offer() {
   .core(&core)
   .ord(&ord)
   .expected_exit_code(1)
-  .expected_stderr(format!(
-    "error: outgoing input {outpoint} contains multiple runes\n"
-  ))
+  .expected_stderr("error: missing runestone in PSBT\n")
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn error_unexpected_runestone_when_utxo_contains_single_rune() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune = Rune(RUNE);
+  let a = etch(&core, &ord, rune);
+
+  core.mine_blocks(1);
+
+  let outpoint = OutPoint {
+    txid: a.output.reveal,
+    vout: 1,
+  };
+
+  core.mine_blocks(1);
+
+  let runestone = Runestone::default();
+
+  let psbt = Psbt::from_unsigned_tx(Transaction {
+    version: Version(2),
+    lock_time: LockTime::ZERO,
+    input: vec![TxIn {
+      previous_output: outpoint,
+      script_sig: ScriptBuf::new(),
+      sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+      witness: Witness::new(),
+    }],
+    output: vec![TxOut {
+      value: Amount::ZERO,
+      script_pubkey: runestone.encipher(),
+    }],
+  })
+  .unwrap();
+
+  let base64 = base64_encode(&psbt.serialize());
+
+  CommandBuilder::new([
+    "--regtest",
+    "wallet",
+    "offer",
+    "accept",
+    "--rune",
+    &format!("1000:{}", rune),
+    "--amount",
+    "1btc",
+    "--psbt",
+    &base64,
+  ])
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .expected_stderr("error: unexpected runestone in PSBT\n")
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn error_unexpected_runestone_when_utxo_contains_multiple_runes() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune0 = Rune(RUNE);
+  let rune1 = Rune(RUNE + 1);
+  let a = etch(&core, &ord, rune0);
+  let b = etch(&core, &ord, rune1);
+
+  let (block0, tx0) = core.tx_index(a.output.reveal);
+  let (block1, tx1) = core.tx_index(b.output.reveal);
+
+  core.mine_blocks(1);
+
+  let address = CommandBuilder::new("--regtest wallet receive")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<ord::subcommand::wallet::receive::Output>()
+    .addresses
+    .into_iter()
+    .next()
+    .unwrap();
+
+  let merge = core.broadcast_tx(TransactionTemplate {
+    inputs: &[(block0, tx0, 1, default()), (block1, tx1, 1, default())],
+    recipient: Some(address.require_network(Network::Regtest).unwrap()),
+    ..default()
+  });
+
+  let outpoint = OutPoint {
+    txid: merge,
+    vout: 0,
+  };
+
+  core.mine_blocks(1);
+
+  let runestone = Runestone::default();
+
+  let psbt = Psbt::from_unsigned_tx(Transaction {
+    version: Version(2),
+    lock_time: LockTime::ZERO,
+    input: vec![TxIn {
+      previous_output: outpoint,
+      script_sig: ScriptBuf::new(),
+      sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+      witness: Witness::new(),
+    }],
+    output: vec![TxOut {
+      value: Amount::ZERO,
+      script_pubkey: runestone.encipher(),
+    }],
+  })
+  .unwrap();
+
+  let base64 = base64_encode(&psbt.serialize());
+
+  CommandBuilder::new([
+    "--regtest",
+    "wallet",
+    "offer",
+    "accept",
+    "--rune",
+    &format!("1000:{}", rune0),
+    "--amount",
+    "1btc",
+    "--psbt",
+    &base64,
+  ])
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .expected_stderr("error: unexpected runestone in PSBT\n")
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn error_unexpected_seller_address_when_utxo_contains_multiple_runes() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune0 = Rune(RUNE);
+  let rune1 = Rune(RUNE + 1);
+  let a = etch(&core, &ord, rune0);
+  let b = etch(&core, &ord, rune1);
+
+  let (block0, tx0) = core.tx_index(a.output.reveal);
+  let (block1, tx1) = core.tx_index(b.output.reveal);
+
+  core.mine_blocks(1);
+
+  let address = core.state().new_address(false);
+
+  let merge = core.broadcast_tx(TransactionTemplate {
+    inputs: &[(block0, tx0, 1, default()), (block1, tx1, 1, default())],
+    recipient: Some(address.clone()),
+    ..default()
+  });
+
+  let outpoint = OutPoint {
+    txid: merge,
+    vout: 0,
+  };
+
+  core.mine_blocks(1);
+
+  let seller_address = core.state().new_address(false);
+
+  core.state().remove_wallet_address(seller_address.clone());
+
+  let runestone = Runestone {
+    edicts: vec![Edict {
+      amount: 0,
+      id: a.id,
+      output: 2,
+    }],
+    ..default()
+  };
+
+  let psbt = Psbt::from_unsigned_tx(Transaction {
+    version: Version(2),
+    lock_time: LockTime::ZERO,
+    input: vec![TxIn {
+      previous_output: outpoint,
+      script_sig: ScriptBuf::new(),
+      sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+      witness: Witness::new(),
+    }],
+    output: vec![
+      TxOut {
+        value: Amount::ZERO,
+        script_pubkey: seller_address.into(),
+      },
+      TxOut {
+        value: Amount::ZERO,
+        script_pubkey: runestone.encipher(),
+      },
+    ],
+  })
+  .unwrap();
+
+  let base64 = base64_encode(&psbt.serialize());
+
+  CommandBuilder::new([
+    "--regtest",
+    "wallet",
+    "offer",
+    "accept",
+    "--rune",
+    &format!("1000:{}", rune0),
+    "--amount",
+    "1btc",
+    "--psbt",
+    &base64,
+  ])
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .expected_stderr("error: unexpected seller address in PSBT\n")
   .run_and_extract_stdout();
 }
 

--- a/tests/wallet/offer/create.rs
+++ b/tests/wallet/offer/create.rs
@@ -31,11 +31,9 @@ fn created_inscription_offer_is_correct() {
     .ord(&ord)
     .run_and_deserialize_output::<Vec<ord::subcommand::wallet::outputs::Output>>();
 
-  let buyer_postage = 8000;
-
   let create = CommandBuilder::new(format!(
-    "wallet offer create --inscription {} --amount 1btc --fee-rate 1 --postage {}sat",
-    inscription, buyer_postage
+    "wallet offer create --inscription {} --amount 1btc --fee-rate 1",
+    inscription
   ))
   .core(&core)
   .ord(&ord)
@@ -282,13 +280,10 @@ fn created_rune_offer_is_correct() {
     vout: 2,
   };
 
-  let buyer_postage = 8_000;
-
   let create = CommandBuilder::new(format!(
-    "--regtest wallet offer create --rune {}:{} --amount 1btc --postage {}sat --fee-rate 1 --utxo {}",
+    "--regtest wallet offer create --rune {}:{} --amount 1btc --fee-rate 1 --utxo {}",
     750,
     Rune(RUNE),
-    buyer_postage,
     outpoint
   ))
   .core(&core)
@@ -367,7 +362,7 @@ fn created_rune_offer_is_correct() {
       ],
       output: vec![
         TxOut {
-          value: Amount::from_sat(buyer_postage),
+          value: Amount::from_sat(seller_postage),
           script_pubkey: psbt.unsigned_tx.output[0].script_pubkey.clone(),
         },
         TxOut {
@@ -375,7 +370,7 @@ fn created_rune_offer_is_correct() {
           script_pubkey: address.clone().into(),
         },
         TxOut {
-          value: Amount::from_sat(payment_input_value - payment - buyer_postage - fee),
+          value: Amount::from_sat(payment_input_value - payment - seller_postage - fee),
           script_pubkey: psbt.unsigned_tx.output[2].script_pubkey.clone(),
         },
       ],
@@ -384,538 +379,6 @@ fn created_rune_offer_is_correct() {
 
   for (i, input) in psbt.inputs.iter().enumerate() {
     if i == 0 {
-      assert_eq!(input.final_script_witness, None);
-    } else {
-      assert!(input.final_script_witness.is_some());
-    }
-  }
-}
-
-#[test]
-fn created_rune_offer_on_utxo_with_multiple_runes_is_correct() {
-  let core = mockcore::builder().network(Network::Regtest).build();
-
-  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
-
-  create_wallet(&core, &ord);
-
-  let rune = Rune(RUNE);
-  let a = etch(&core, &ord, rune);
-  let b = etch(&core, &ord, Rune(RUNE + 1));
-
-  let (a_block, a_tx) = core.tx_index(a.output.reveal);
-  let (b_block, b_tx) = core.tx_index(b.output.reveal);
-
-  core.mine_blocks(1);
-
-  let address = core.state().new_address(false);
-
-  let merge = core.broadcast_tx(TransactionTemplate {
-    inputs: &[(a_block, a_tx, 1, default()), (b_block, b_tx, 1, default())],
-    recipient: Some(address.clone()),
-    ..default()
-  });
-
-  core.mine_blocks(1);
-
-  core.state().remove_wallet_address(address.clone());
-
-  let outpoint = OutPoint {
-    txid: merge,
-    vout: 0,
-  };
-
-  let buyer_postage = 8_000;
-  let seller_postage = 20_000;
-
-  let create = CommandBuilder::new(format!(
-    "--regtest wallet offer create --rune {}:{} --amount 1btc --postage {}sat --fee-rate 1 --utxo {}",
-    1000,
-    rune,
-    buyer_postage,
-    outpoint
-  ))
-  .core(&core)
-  .ord(&ord)
-  .run_and_deserialize_output::<Create>();
-
-  assert_eq!(
-    create
-      .seller_address
-      .clone()
-      .require_network(Network::Regtest)
-      .unwrap(),
-    address,
-  );
-
-  assert_eq!(create.inscription, None);
-
-  assert_eq!(
-    create.rune,
-    Some(Outgoing::Rune {
-      rune: SpacedRune {
-        rune: Rune(RUNE),
-        spacers: 0,
-      },
-      decimal: "1000".parse().unwrap(),
-    })
-  );
-
-  let outputs = CommandBuilder::new("--regtest wallet outputs")
-    .core(&core)
-    .ord(&ord)
-    .run_and_deserialize_output::<Vec<ord::subcommand::wallet::outputs::Output>>();
-
-  let psbt = Psbt::deserialize(&base64_decode(&create.psbt).unwrap()).unwrap();
-
-  let payment_input = psbt.unsigned_tx.input[1].previous_output;
-
-  assert!(outputs.iter().any(|output| output.output == payment_input));
-
-  let payment_input_value = outputs
-    .iter()
-    .find(|o| o.output == payment_input)
-    .map_or(0, |o| o.amount);
-
-  for (i, output) in psbt.unsigned_tx.output.iter().enumerate() {
-    if i > 1 && !output.script_pubkey.is_op_return() {
-      assert!(core.state().is_wallet_address(
-        &Address::from_script(&output.script_pubkey, Network::Regtest).unwrap()
-      ));
-    }
-  }
-
-  let payment = 100_000_000;
-  let fee = 298;
-
-  let fee_rate = fee as f64 / psbt.unsigned_tx.vsize() as f64;
-
-  assert!((fee_rate - 1.0).abs() < 0.1);
-
-  let runestone = Runestone {
-    edicts: vec![Edict {
-      amount: 0,
-      id: a.id,
-      output: 2,
-    }],
-    ..default()
-  };
-
-  pretty_assertions::assert_eq!(
-    psbt.unsigned_tx,
-    Transaction {
-      version: Version(2),
-      lock_time: LockTime::ZERO,
-      input: vec![
-        TxIn {
-          previous_output: OutPoint {
-            txid: merge,
-            vout: 0,
-          },
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-          witness: Witness::new(),
-        },
-        TxIn {
-          previous_output: payment_input,
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-          witness: Witness::new(),
-        }
-      ],
-      output: vec![
-        TxOut {
-          value: Amount::from_sat(seller_postage),
-          script_pubkey: address.clone().into(),
-        },
-        TxOut {
-          value: Amount::from_sat(payment),
-          script_pubkey: address.clone().into(),
-        },
-        TxOut {
-          value: Amount::from_sat(buyer_postage),
-          script_pubkey: psbt.unsigned_tx.output[2].script_pubkey.clone(),
-        },
-        TxOut {
-          value: Amount::ZERO,
-          script_pubkey: runestone.encipher(),
-        },
-        TxOut {
-          value: Amount::from_sat(payment_input_value - payment - buyer_postage - fee),
-          script_pubkey: psbt.unsigned_tx.output[4].script_pubkey.clone(),
-        },
-      ],
-    }
-  );
-
-  for (i, input) in psbt.inputs.iter().enumerate() {
-    if i == 0 {
-      assert_eq!(input.final_script_witness, None);
-    } else {
-      assert!(input.final_script_witness.is_some());
-    }
-  }
-}
-
-#[test]
-fn created_rune_offer_on_multiple_utxos_is_correct() {
-  let core = mockcore::builder().network(Network::Regtest).build();
-
-  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
-
-  create_wallet(&core, &ord);
-
-  let rune = Rune(RUNE);
-  etch(&core, &ord, rune);
-
-  core.mine_blocks(1);
-
-  let send = CommandBuilder::new(format!(
-    "
-      --regtest
-      wallet
-      send
-      --fee-rate 1
-      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 500:{}
-    ",
-    Rune(RUNE),
-  ))
-  .core(&core)
-  .ord(&ord)
-  .run_and_deserialize_output::<Send>();
-
-  core.mine_blocks(1);
-
-  let seller_address = Address::from_script(
-    &core.tx_by_id(send.txid).output[1].script_pubkey,
-    Network::Regtest,
-  )
-  .unwrap();
-
-  core.state().remove_wallet_address(seller_address.clone());
-
-  let utxo0 = OutPoint {
-    txid: send.txid,
-    vout: 1,
-  };
-
-  let utxo1 = OutPoint {
-    txid: send.txid,
-    vout: 2,
-  };
-
-  let buyer_postage = 8_000;
-  let seller_postage = 20_000;
-
-  let create = CommandBuilder::new(format!(
-    "--regtest wallet offer create --rune {}:{} --amount 1btc --postage {}sat --fee-rate 1 --utxo {} --utxo {}",
-    1000,
-    rune,
-    buyer_postage,
-    utxo0,
-    utxo1,
-  ))
-  .core(&core)
-  .ord(&ord)
-  .run_and_deserialize_output::<Create>();
-
-  assert_eq!(
-    create
-      .seller_address
-      .clone()
-      .require_network(Network::Regtest)
-      .unwrap(),
-    seller_address,
-  );
-
-  assert_eq!(create.inscription, None);
-
-  assert_eq!(
-    create.rune,
-    Some(Outgoing::Rune {
-      rune: SpacedRune {
-        rune: Rune(RUNE),
-        spacers: 0,
-      },
-      decimal: "1000".parse().unwrap(),
-    })
-  );
-
-  let outputs = CommandBuilder::new("--regtest wallet outputs")
-    .core(&core)
-    .ord(&ord)
-    .run_and_deserialize_output::<Vec<ord::subcommand::wallet::outputs::Output>>();
-
-  let psbt = Psbt::deserialize(&base64_decode(&create.psbt).unwrap()).unwrap();
-
-  let payment_input = psbt.unsigned_tx.input[2].previous_output;
-
-  assert!(outputs.iter().any(|output| output.output == payment_input));
-
-  let payment_input_value = outputs
-    .iter()
-    .find(|o| o.output == payment_input)
-    .map_or(0, |o| o.amount);
-
-  for (i, output) in psbt.unsigned_tx.output.iter().enumerate() {
-    if i != 1 {
-      assert!(core.state().is_wallet_address(
-        &Address::from_script(&output.script_pubkey, Network::Regtest).unwrap()
-      ));
-    }
-  }
-
-  let payment = 100_000_000;
-  let fee = 279;
-
-  let fee_rate = fee as f64 / psbt.unsigned_tx.vsize() as f64;
-
-  assert!((fee_rate - 1.0).abs() < 0.1);
-
-  pretty_assertions::assert_eq!(
-    psbt.unsigned_tx,
-    Transaction {
-      version: Version(2),
-      lock_time: LockTime::ZERO,
-      input: vec![
-        TxIn {
-          previous_output: utxo0,
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-          witness: Witness::new(),
-        },
-        TxIn {
-          previous_output: utxo1,
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-          witness: Witness::new(),
-        },
-        TxIn {
-          previous_output: payment_input,
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-          witness: Witness::new(),
-        }
-      ],
-      output: vec![
-        TxOut {
-          value: Amount::from_sat(buyer_postage),
-          script_pubkey: psbt.unsigned_tx.output[0].script_pubkey.clone(),
-        },
-        TxOut {
-          value: Amount::from_sat(seller_postage + payment),
-          script_pubkey: seller_address.clone().into(),
-        },
-        TxOut {
-          value: Amount::from_sat(payment_input_value - payment - buyer_postage - fee),
-          script_pubkey: psbt.unsigned_tx.output[2].script_pubkey.clone(),
-        },
-      ],
-    }
-  );
-
-  for (i, input) in psbt.inputs.iter().enumerate() {
-    if i <= 1 {
-      assert_eq!(input.final_script_witness, None);
-    } else {
-      assert!(input.final_script_witness.is_some());
-    }
-  }
-}
-
-#[test]
-fn created_rune_offer_on_multiple_utxos_with_multiple_runes_is_correct() {
-  let core = mockcore::builder().network(Network::Regtest).build();
-
-  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
-
-  create_wallet(&core, &ord);
-
-  let rune = Rune(RUNE);
-  let a = etch(&core, &ord, rune);
-  let b = etch(&core, &ord, Rune(RUNE + 1));
-
-  core.mine_blocks(1);
-
-  let send = CommandBuilder::new(format!(
-    "
-      --regtest
-      wallet
-      send
-      --fee-rate 1
-      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 500:{}
-    ",
-    Rune(RUNE),
-  ))
-  .core(&core)
-  .ord(&ord)
-  .run_and_deserialize_output::<Send>();
-
-  core.mine_blocks(1);
-
-  let (a_block, a_tx) = core.tx_index(send.txid);
-  let (b_block, b_tx) = core.tx_index(b.output.reveal);
-
-  let seller_address = CommandBuilder::new("--regtest wallet receive")
-    .core(&core)
-    .ord(&ord)
-    .run_and_deserialize_output::<ord::subcommand::wallet::receive::Output>()
-    .addresses
-    .into_iter()
-    .next()
-    .unwrap()
-    .require_network(Network::Regtest)
-    .unwrap();
-
-  let merge = core.broadcast_tx(TransactionTemplate {
-    inputs: &[(a_block, a_tx, 1, default()), (b_block, b_tx, 1, default())],
-    recipient: Some(seller_address.clone()),
-    ..default()
-  });
-
-  core.mine_blocks(1);
-
-  core.state().remove_wallet_address(seller_address.clone());
-
-  let utxo0 = OutPoint {
-    txid: merge,
-    vout: 0,
-  };
-
-  let utxo1 = OutPoint {
-    txid: send.txid,
-    vout: 2,
-  };
-
-  let buyer_postage = 8_000;
-  let seller_postage = 30_000;
-
-  let create = CommandBuilder::new(format!(
-    "--regtest wallet offer create --rune {}:{} --amount 1btc --postage {}sat --fee-rate 1 --utxo {} --utxo {}",
-    1000,
-    rune,
-    buyer_postage,
-    utxo0,
-    utxo1,
-  ))
-  .core(&core)
-  .ord(&ord)
-  .run_and_deserialize_output::<Create>();
-
-  assert_eq!(
-    create
-      .seller_address
-      .clone()
-      .require_network(Network::Regtest)
-      .unwrap(),
-    seller_address.clone(),
-  );
-
-  assert_eq!(create.inscription, None);
-
-  assert_eq!(
-    create.rune,
-    Some(Outgoing::Rune {
-      rune: SpacedRune {
-        rune: Rune(RUNE),
-        spacers: 0,
-      },
-      decimal: "1000".parse().unwrap(),
-    })
-  );
-
-  let outputs = CommandBuilder::new("--regtest wallet outputs")
-    .core(&core)
-    .ord(&ord)
-    .run_and_deserialize_output::<Vec<ord::subcommand::wallet::outputs::Output>>();
-
-  let psbt = Psbt::deserialize(&base64_decode(&create.psbt).unwrap()).unwrap();
-
-  let payment_input = psbt.unsigned_tx.input[2].previous_output;
-
-  assert!(outputs.iter().any(|output| output.output == payment_input));
-
-  let payment_input_value = outputs
-    .iter()
-    .find(|o| o.output == payment_input)
-    .map_or(0, |o| o.amount);
-
-  for (i, output) in psbt.unsigned_tx.output.iter().enumerate() {
-    if i > 1 && !output.script_pubkey.is_op_return() {
-      assert!(core.state().is_wallet_address(
-        &Address::from_script(&output.script_pubkey, Network::Regtest).unwrap()
-      ));
-    }
-  }
-
-  let payment = 100_000_000;
-  let fee = 339;
-
-  let fee_rate = fee as f64 / psbt.unsigned_tx.vsize() as f64;
-
-  assert!((fee_rate - 1.0).abs() < 0.1);
-
-  let runestone = Runestone {
-    edicts: vec![Edict {
-      amount: 0,
-      id: a.id,
-      output: 2,
-    }],
-    ..default()
-  };
-
-  pretty_assertions::assert_eq!(
-    psbt.unsigned_tx,
-    Transaction {
-      version: Version(2),
-      lock_time: LockTime::ZERO,
-      input: vec![
-        TxIn {
-          previous_output: utxo0,
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-          witness: Witness::new(),
-        },
-        TxIn {
-          previous_output: utxo1,
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-          witness: Witness::new(),
-        },
-        TxIn {
-          previous_output: payment_input,
-          script_sig: ScriptBuf::new(),
-          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
-          witness: Witness::new(),
-        }
-      ],
-      output: vec![
-        TxOut {
-          value: Amount::from_sat(seller_postage),
-          script_pubkey: seller_address.clone().into(),
-        },
-        TxOut {
-          value: Amount::from_sat(payment),
-          script_pubkey: seller_address.clone().into(),
-        },
-        TxOut {
-          value: Amount::from_sat(buyer_postage),
-          script_pubkey: psbt.unsigned_tx.output[2].script_pubkey.clone(),
-        },
-        TxOut {
-          value: Amount::ZERO,
-          script_pubkey: runestone.encipher(),
-        },
-        TxOut {
-          value: Amount::from_sat(payment_input_value - payment - buyer_postage - fee),
-          script_pubkey: psbt.unsigned_tx.output[4].script_pubkey.clone(),
-        },
-      ],
-    }
-  );
-
-  for (i, input) in psbt.inputs.iter().enumerate() {
-    if i <= 1 {
       assert_eq!(input.final_script_witness, None);
     } else {
       assert!(input.final_script_witness.is_some());
@@ -1087,7 +550,7 @@ fn utxo_must_hold_runes() {
 }
 
 #[test]
-fn utxo_holds_more_runes_than_expected() {
+fn utxo_holds_unexpected_rune_balance() {
   let core = mockcore::builder().network(Network::Regtest).build();
 
   let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
@@ -1124,52 +587,7 @@ fn utxo_holds_more_runes_than_expected() {
   .core(&core)
   .ord(&ord)
   .expected_stderr(format!(
-    "error: utxo(s) hold more {} than expected (750 > 1)\n",
-    Rune(RUNE)
-  ))
-  .expected_exit_code(1)
-  .run_and_extract_stdout();
-}
-
-#[test]
-fn utxo_holds_fewer_runes_than_required() {
-  let core = mockcore::builder().network(Network::Regtest).build();
-
-  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
-
-  create_wallet(&core, &ord);
-
-  etch(&core, &ord, Rune(RUNE));
-
-  let send = CommandBuilder::new(format!(
-    "
-      --regtest
-      wallet
-      send
-      --fee-rate 1
-      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 750:{}
-    ",
-    Rune(RUNE),
-  ))
-  .core(&core)
-  .ord(&ord)
-  .run_and_deserialize_output::<Send>();
-
-  core.mine_blocks(1);
-
-  let outpoint = OutPoint {
-    txid: send.txid,
-    vout: 2,
-  };
-
-  CommandBuilder::new(format!(
-    "--regtest wallet offer create --rune 1000:{} --amount 1btc --fee-rate 1 --utxo {outpoint}",
-    Rune(RUNE)
-  ))
-  .core(&core)
-  .ord(&ord)
-  .expected_stderr(format!(
-    "error: utxo(s) hold less {} than required (750 < 1000)\n",
+    "error: utxo holds unexpected {} balance (expected 1, found 750)\n",
     Rune(RUNE)
   ))
   .expected_exit_code(1)
@@ -1222,8 +640,11 @@ fn error_must_include_either_inscription_or_rune() {
   CommandBuilder::new("--regtest wallet offer create --amount 1btc --fee-rate 1")
     .core(&core)
     .ord(&ord)
-    .expected_stderr("error: must include either --inscription or --rune\n")
-    .expected_exit_code(1)
+    .stderr_regex(
+      ".*error: the following required arguments were not provided:
+  .*<--inscription <INSCRIPTION>|--rune <RUNE>>.*",
+    )
+    .expected_exit_code(2)
     .run_and_extract_stdout();
 }
 
@@ -1244,8 +665,10 @@ fn error_cannot_include_both_inscription_and_rune() {
   ))
   .core(&core)
   .ord(&ord)
-  .expected_stderr("error: cannot include both --inscription and --rune\n")
-  .expected_exit_code(1)
+  .stderr_regex(
+    "error: the argument '--inscription <INSCRIPTION>' cannot be used with '--rune <RUNE>'.*",
+  )
+  .expected_exit_code(2)
   .run_and_extract_stdout();
 }
 
@@ -1268,5 +691,59 @@ fn error_rune_not_properly_formatted() {
   .ord(&ord)
   .expected_stderr("error: invalid format for --rune (must be `DECIMAL:RUNE`)\n")
   .expected_exit_code(1)
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn error_contains_multiple_runes() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune0 = Rune(RUNE);
+  let rune1 = Rune(RUNE + 1);
+  let a = etch(&core, &ord, rune0);
+  let b = etch(&core, &ord, rune1);
+
+  let (block0, tx0) = core.tx_index(a.output.reveal);
+  let (block1, tx1) = core.tx_index(b.output.reveal);
+
+  core.mine_blocks(1);
+
+  let address = CommandBuilder::new("--regtest wallet receive")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<ord::subcommand::wallet::receive::Output>()
+    .addresses
+    .into_iter()
+    .next()
+    .unwrap()
+    .require_network(Network::Regtest)
+    .unwrap();
+
+  let merge = core.broadcast_tx(TransactionTemplate {
+    inputs: &[(block0, tx0, 1, default()), (block1, tx1, 1, default())],
+    recipient: Some(address.clone()),
+    ..default()
+  });
+
+  let outpoint = OutPoint {
+    txid: merge,
+    vout: 0,
+  };
+
+  core.mine_blocks(1);
+
+  core.state().remove_wallet_address(address);
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune 1000:{rune0} --amount 1btc --fee-rate 1 --utxo {outpoint}"
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_exit_code(1)
+  .expected_stderr(format!("error: utxo {outpoint} holds multiple runes\n"))
   .run_and_extract_stdout();
 }

--- a/tests/wallet/offer/create.rs
+++ b/tests/wallet/offer/create.rs
@@ -394,12 +394,16 @@ fn rune_must_exist() {
 
   create_wallet(&core, &ord);
 
-  CommandBuilder::new("--regtest wallet offer create --rune 1:FOO --amount 1btc --fee-rate 1")
-    .core(&core)
-    .ord(&ord)
-    .expected_stderr("error: rune `FOO` has not been etched\n")
-    .expected_exit_code(1)
-    .run_and_extract_stdout();
+  let utxo = OutPoint::null();
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune 1:FOO --amount 1btc --utxo {utxo} --fee-rate 1"
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr("error: rune `FOO` has not been etched\n")
+  .expected_exit_code(1)
+  .run_and_extract_stdout();
 }
 
 #[test]
@@ -418,8 +422,11 @@ fn utxo_must_be_set_in_rune_offer() {
   ))
   .core(&core)
   .ord(&ord)
-  .expected_stderr("error: --utxo must be set\n")
-  .expected_exit_code(1)
+  .stderr_regex(
+    ".*error: the following required arguments were not provided:
+.*--utxo <UTXO>.*",
+  )
+  .expected_exit_code(2)
   .run_and_extract_stdout();
 }
 
@@ -684,8 +691,10 @@ fn error_rune_not_properly_formatted() {
 
   core.mine_blocks(1);
 
+  let utxo = OutPoint::null();
+
   CommandBuilder::new(format!(
-    "wallet offer create --rune {inscription} --amount 1btc --fee-rate 1"
+    "wallet offer create --rune {inscription} --amount 1btc --utxo {utxo} --fee-rate 1"
   ))
   .core(&core)
   .ord(&ord)

--- a/tests/wallet/offer/create.rs
+++ b/tests/wallet/offer/create.rs
@@ -3,14 +3,15 @@ use super::*;
 type Create = ord::subcommand::wallet::offer::create::Output;
 
 #[test]
-fn created_offer_is_correct() {
+fn created_inscription_offer_is_correct() {
   let core = mockcore::spawn();
 
   let ord = TestServer::spawn_with_server_args(&core, &[], &[]);
 
   create_wallet(&core, &ord);
 
-  let (inscription, _) = inscribe_with_options(&core, &ord, Some(9000), 0);
+  let seller_postage = 9000;
+  let (inscription, _) = inscribe_with_options(&core, &ord, Some(seller_postage), 0);
 
   let address = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
     .parse::<Address<NetworkUnchecked>>()
@@ -30,8 +31,11 @@ fn created_offer_is_correct() {
     .ord(&ord)
     .run_and_deserialize_output::<Vec<ord::subcommand::wallet::outputs::Output>>();
 
+  let buyer_postage = 8000;
+
   let create = CommandBuilder::new(format!(
-    "wallet offer create --inscription {inscription} --amount 1btc --fee-rate 1"
+    "wallet offer create --inscription {} --amount 1btc --fee-rate 1 --postage {}sat",
+    inscription, buyer_postage
   ))
   .core(&core)
   .ord(&ord)
@@ -45,7 +49,8 @@ fn created_offer_is_correct() {
     address,
   );
 
-  assert_eq!(create.inscription, inscription);
+  assert_eq!(create.inscription, Some(inscription));
+  assert_eq!(create.rune, None);
 
   let psbt = Psbt::deserialize(&base64_decode(&create.psbt).unwrap()).unwrap();
 
@@ -61,7 +66,7 @@ fn created_offer_is_correct() {
     }
   }
 
-  let payment = 100_009_000;
+  let payment = 100_000_000;
   let fee = 226;
 
   let fee_rate = fee as f64 / psbt.unsigned_tx.vsize() as f64;
@@ -92,15 +97,15 @@ fn created_offer_is_correct() {
       ],
       output: vec![
         TxOut {
-          value: Amount::from_sat(9_000),
+          value: Amount::from_sat(seller_postage),
           script_pubkey: psbt.unsigned_tx.output[0].script_pubkey.clone(),
         },
         TxOut {
-          value: Amount::from_sat(payment),
+          value: Amount::from_sat(seller_postage + payment),
           script_pubkey: address.clone().into(),
         },
         TxOut {
-          value: Amount::from_sat(5_000_000_000 - payment - fee),
+          value: Amount::from_sat(5_000_000_000 - payment - seller_postage - fee),
           script_pubkey: psbt.unsigned_tx.output[2].script_pubkey.clone(),
         },
       ],
@@ -182,6 +187,542 @@ fn inscription_must_have_valid_address() {
   .expected_stderr(format!(
     "error: inscription {inscription} script pubkey not valid address\n"
   ))
+  .expected_exit_code(1)
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn inscription_must_match_utxo_if_provided() {
+  let core = mockcore::spawn();
+
+  let ord = TestServer::spawn_with_server_args(&core, &[], &[]);
+
+  create_wallet(&core, &ord);
+
+  let (inscription, _) = inscribe(&core, &ord);
+
+  let send = CommandBuilder::new(format!(
+    "wallet send --fee-rate 0 bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4 {inscription}"
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let correct_outpoint = OutPoint {
+    txid: send.txid,
+    vout: 0,
+  };
+
+  CommandBuilder::new(format!(
+    "wallet offer create --inscription {inscription} --amount 1btc --fee-rate 1 --utxo {correct_outpoint}",
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  let incorrect_outpoint = OutPoint::null();
+
+  CommandBuilder::new(format!(
+    "wallet offer create --inscription {inscription} --amount 1btc --fee-rate 1 --utxo {incorrect_outpoint}",
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr(format!(
+    "error: inscription utxo {correct_outpoint} does not match provided utxo {incorrect_outpoint}\n"
+  ))
+  .expected_exit_code(1)
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn created_rune_offer_is_correct() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE));
+
+  let seller_postage = 9000;
+
+  let address = "bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw"
+    .parse::<Address<NetworkUnchecked>>()
+    .unwrap()
+    .require_network(Network::Regtest)
+    .unwrap();
+
+  let send = CommandBuilder::new(format!(
+    "
+      --regtest
+      wallet
+      send
+      --fee-rate 1
+      --postage {}sats
+      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 750:{}
+    ",
+    seller_postage,
+    Rune(RUNE),
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let outputs = CommandBuilder::new("--regtest wallet outputs")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Vec<ord::subcommand::wallet::outputs::Output>>();
+
+  let outpoint = OutPoint {
+    txid: send.txid,
+    vout: 2,
+  };
+
+  let buyer_postage = 8_000;
+
+  let create = CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune {}:{} --amount 1btc --postage {}sat --fee-rate 1 --utxo {}",
+    750,
+    Rune(RUNE),
+    buyer_postage,
+    outpoint
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  assert_eq!(
+    create
+      .seller_address
+      .clone()
+      .require_network(Network::Regtest)
+      .unwrap(),
+    address,
+  );
+
+  assert_eq!(create.inscription, None);
+
+  assert_eq!(
+    create.rune,
+    Some(Outgoing::Rune {
+      rune: SpacedRune {
+        rune: Rune(RUNE),
+        spacers: 0,
+      },
+      decimal: "750".parse().unwrap(),
+    })
+  );
+
+  let psbt = Psbt::deserialize(&base64_decode(&create.psbt).unwrap()).unwrap();
+
+  let payment_input = psbt.unsigned_tx.input[1].previous_output;
+
+  assert!(outputs.iter().any(|output| output.output == payment_input));
+
+  let payment_input_value = outputs
+    .iter()
+    .find(|o| o.output == payment_input)
+    .map_or(0, |o| o.amount);
+
+  for (i, output) in psbt.unsigned_tx.output.iter().enumerate() {
+    if i != 1 {
+      assert!(core.state().is_wallet_address(
+        &Address::from_script(&output.script_pubkey, Network::Regtest).unwrap()
+      ));
+    }
+  }
+
+  let payment = 100_000_000;
+  let fee = 226;
+
+  let fee_rate = fee as f64 / psbt.unsigned_tx.vsize() as f64;
+
+  assert!((fee_rate - 1.0).abs() < 0.1);
+
+  println!("{}", psbt.fee().unwrap().to_sat());
+
+  pretty_assertions::assert_eq!(
+    psbt.unsigned_tx,
+    Transaction {
+      version: Version(2),
+      lock_time: LockTime::ZERO,
+      input: vec![
+        TxIn {
+          previous_output: OutPoint {
+            txid: send.txid,
+            vout: 2,
+          },
+          script_sig: ScriptBuf::new(),
+          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+          witness: Witness::new(),
+        },
+        TxIn {
+          previous_output: payment_input,
+          script_sig: ScriptBuf::new(),
+          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+          witness: Witness::new(),
+        }
+      ],
+      output: vec![
+        TxOut {
+          value: Amount::from_sat(buyer_postage),
+          script_pubkey: psbt.unsigned_tx.output[0].script_pubkey.clone(),
+        },
+        TxOut {
+          value: Amount::from_sat(seller_postage + payment),
+          script_pubkey: address.clone().into(),
+        },
+        TxOut {
+          value: Amount::from_sat(payment_input_value - payment - buyer_postage - fee),
+          script_pubkey: psbt.unsigned_tx.output[2].script_pubkey.clone(),
+        },
+      ],
+    }
+  );
+
+  for (i, input) in psbt.inputs.iter().enumerate() {
+    if i == 0 {
+      assert_eq!(input.final_script_witness, None);
+    } else {
+      assert!(input.final_script_witness.is_some());
+    }
+  }
+}
+
+#[test]
+fn rune_must_exist() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  CommandBuilder::new("--regtest wallet offer create --rune 1:FOO --amount 1btc --fee-rate 1")
+    .core(&core)
+    .ord(&ord)
+    .expected_stderr("error: rune `FOO` has not been etched\n")
+    .expected_exit_code(1)
+    .run_and_extract_stdout();
+}
+
+#[test]
+fn utxo_must_be_set_in_rune_offer() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE));
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune 1:{} --amount 1btc --fee-rate 1",
+    Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr("error: --utxo must be set\n")
+  .expected_exit_code(1)
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn utxo_must_not_be_in_wallet() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE));
+
+  let send = CommandBuilder::new(format!(
+    "
+      --regtest
+      wallet
+      send
+      --fee-rate 1
+      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 750:{}
+    ",
+    Rune(RUNE),
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let outpoint = OutPoint {
+    txid: send.txid,
+    vout: 1,
+  };
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune 1:{} --amount 1btc --fee-rate 1 --utxo {outpoint}",
+    Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr(format!("error: utxo {} already in wallet\n", outpoint))
+  .expected_exit_code(1)
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn utxo_must_exist() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE));
+
+  let send = CommandBuilder::new(
+    "
+      --regtest
+      wallet
+      send
+      --fee-rate 1
+      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 1000sats
+    ",
+  )
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  let outpoint = OutPoint {
+    txid: send.txid,
+    vout: 0,
+  };
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune 1:{} --amount 1btc --fee-rate 1 --utxo {outpoint}",
+    Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr(format!("error: utxo {} does not exist\n", outpoint))
+  .expected_exit_code(1)
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn utxo_must_hold_runes() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE));
+
+  let send = CommandBuilder::new(
+    "
+      --regtest
+      wallet
+      send
+      --fee-rate 1
+      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 1000sats
+    ",
+  )
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let outpoint = OutPoint {
+    txid: send.txid,
+    vout: 0,
+  };
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune 1:{} --amount 1btc --fee-rate 1 --utxo {outpoint}",
+    Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr(format!(
+    "error: utxo {} does not hold any {} runes\n",
+    outpoint,
+    Rune(RUNE)
+  ))
+  .expected_exit_code(1)
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn utxo_holds_more_runes_than_expected() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE));
+
+  let send = CommandBuilder::new(format!(
+    "
+      --regtest
+      wallet
+      send
+      --fee-rate 1
+      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 750:{}
+    ",
+    Rune(RUNE),
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let outpoint = OutPoint {
+    txid: send.txid,
+    vout: 2,
+  };
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune 1:{} --amount 1btc --fee-rate 1 --utxo {outpoint}",
+    Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr(format!(
+    "error: utxo {} holds more {} than expected (750 > 1)\n",
+    outpoint,
+    Rune(RUNE)
+  ))
+  .expected_exit_code(1)
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn utxo_holds_fewer_runes_than_required() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  etch(&core, &ord, Rune(RUNE));
+
+  let send = CommandBuilder::new(format!(
+    "
+      --regtest
+      wallet
+      send
+      --fee-rate 1
+      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 750:{}
+    ",
+    Rune(RUNE),
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let outpoint = OutPoint {
+    txid: send.txid,
+    vout: 2,
+  };
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune 1000:{} --amount 1btc --fee-rate 1 --utxo {outpoint}",
+    Rune(RUNE)
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr(format!(
+    "error: utxo {} holds less {} than required (750 < 1000)\n",
+    outpoint,
+    Rune(RUNE)
+  ))
+  .expected_exit_code(1)
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn utxo_must_have_valid_address() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune = Rune(RUNE);
+  etch(&core, &ord, rune);
+
+  let send = CommandBuilder::new(format!("--regtest wallet burn --fee-rate 1 500:{rune}",))
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let outpoint = OutPoint {
+    txid: send.txid,
+    vout: 0,
+  };
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune 750:{rune} --amount 1btc --fee-rate 1 --utxo {outpoint}"
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr(format!(
+    "error: utxo {outpoint} script pubkey not valid address\n"
+  ))
+  .expected_exit_code(1)
+  .run_and_extract_stdout();
+}
+
+#[test]
+fn utxo_can_only_hold_one_rune() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune = Rune(RUNE);
+  let a = etch(&core, &ord, rune);
+  let b = etch(&core, &ord, Rune(RUNE + 1));
+
+  let (a_block, a_tx) = core.tx_index(a.output.reveal);
+  let (b_block, b_tx) = core.tx_index(b.output.reveal);
+
+  core.mine_blocks(1);
+
+  let address = core.state().new_address(false);
+
+  let merge = core.broadcast_tx(TransactionTemplate {
+    inputs: &[(a_block, a_tx, 1, default()), (b_block, b_tx, 1, default())],
+    recipient: Some(address.clone()),
+    ..default()
+  });
+
+  core.mine_blocks(1);
+
+  let outpoint = OutPoint {
+    txid: merge,
+    vout: 0,
+  };
+
+  core.state().remove_wallet_address(address);
+
+  CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune 1000:{rune} --amount 1btc --fee-rate 1 --utxo {outpoint}"
+  ))
+  .core(&core)
+  .ord(&ord)
+  .expected_stderr(format!("error: utxo {outpoint} holds multiple runes\n"))
   .expected_exit_code(1)
   .run_and_extract_stdout();
 }

--- a/tests/wallet/offer/create.rs
+++ b/tests/wallet/offer/create.rs
@@ -558,6 +558,372 @@ fn created_rune_offer_on_utxo_with_multiple_runes_is_correct() {
 }
 
 #[test]
+fn created_rune_offer_on_multiple_utxos_is_correct() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune = Rune(RUNE);
+  etch(&core, &ord, rune);
+
+  core.mine_blocks(1);
+
+  let send = CommandBuilder::new(format!(
+    "
+      --regtest
+      wallet
+      send
+      --fee-rate 1
+      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 500:{}
+    ",
+    Rune(RUNE),
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let seller_address = Address::from_script(
+    &core.tx_by_id(send.txid).output[1].script_pubkey,
+    Network::Regtest,
+  )
+  .unwrap();
+
+  core.state().remove_wallet_address(seller_address.clone());
+
+  let utxo0 = OutPoint {
+    txid: send.txid,
+    vout: 1,
+  };
+
+  let utxo1 = OutPoint {
+    txid: send.txid,
+    vout: 2,
+  };
+
+  let buyer_postage = 8_000;
+  let seller_postage = 20_000;
+
+  let create = CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune {}:{} --amount 1btc --postage {}sat --fee-rate 1 --utxo {} --utxo {}",
+    1000,
+    rune,
+    buyer_postage,
+    utxo0,
+    utxo1,
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  assert_eq!(
+    create
+      .seller_address
+      .clone()
+      .require_network(Network::Regtest)
+      .unwrap(),
+    seller_address,
+  );
+
+  assert_eq!(create.inscription, None);
+
+  assert_eq!(
+    create.rune,
+    Some(Outgoing::Rune {
+      rune: SpacedRune {
+        rune: Rune(RUNE),
+        spacers: 0,
+      },
+      decimal: "1000".parse().unwrap(),
+    })
+  );
+
+  let outputs = CommandBuilder::new("--regtest wallet outputs")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Vec<ord::subcommand::wallet::outputs::Output>>();
+
+  let psbt = Psbt::deserialize(&base64_decode(&create.psbt).unwrap()).unwrap();
+
+  let payment_input = psbt.unsigned_tx.input[2].previous_output;
+
+  assert!(outputs.iter().any(|output| output.output == payment_input));
+
+  let payment_input_value = outputs
+    .iter()
+    .find(|o| o.output == payment_input)
+    .map_or(0, |o| o.amount);
+
+  for (i, output) in psbt.unsigned_tx.output.iter().enumerate() {
+    if i != 1 {
+      assert!(core.state().is_wallet_address(
+        &Address::from_script(&output.script_pubkey, Network::Regtest).unwrap()
+      ));
+    }
+  }
+
+  let payment = 100_000_000;
+  let fee = 279;
+
+  let fee_rate = fee as f64 / psbt.unsigned_tx.vsize() as f64;
+
+  assert!((fee_rate - 1.0).abs() < 0.1);
+
+  pretty_assertions::assert_eq!(
+    psbt.unsigned_tx,
+    Transaction {
+      version: Version(2),
+      lock_time: LockTime::ZERO,
+      input: vec![
+        TxIn {
+          previous_output: utxo0,
+          script_sig: ScriptBuf::new(),
+          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+          witness: Witness::new(),
+        },
+        TxIn {
+          previous_output: utxo1,
+          script_sig: ScriptBuf::new(),
+          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+          witness: Witness::new(),
+        },
+        TxIn {
+          previous_output: payment_input,
+          script_sig: ScriptBuf::new(),
+          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+          witness: Witness::new(),
+        }
+      ],
+      output: vec![
+        TxOut {
+          value: Amount::from_sat(buyer_postage),
+          script_pubkey: psbt.unsigned_tx.output[0].script_pubkey.clone(),
+        },
+        TxOut {
+          value: Amount::from_sat(seller_postage + payment),
+          script_pubkey: seller_address.clone().into(),
+        },
+        TxOut {
+          value: Amount::from_sat(payment_input_value - payment - buyer_postage - fee),
+          script_pubkey: psbt.unsigned_tx.output[2].script_pubkey.clone(),
+        },
+      ],
+    }
+  );
+
+  for (i, input) in psbt.inputs.iter().enumerate() {
+    if i <= 1 {
+      assert_eq!(input.final_script_witness, None);
+    } else {
+      assert!(input.final_script_witness.is_some());
+    }
+  }
+}
+
+#[test]
+fn created_rune_offer_on_multiple_utxos_with_multiple_runes_is_correct() {
+  let core = mockcore::builder().network(Network::Regtest).build();
+
+  let ord = TestServer::spawn_with_server_args(&core, &["--index-runes", "--regtest"], &[]);
+
+  create_wallet(&core, &ord);
+
+  let rune = Rune(RUNE);
+  let a = etch(&core, &ord, rune);
+  let b = etch(&core, &ord, Rune(RUNE + 1));
+
+  core.mine_blocks(1);
+
+  let send = CommandBuilder::new(format!(
+    "
+      --regtest
+      wallet
+      send
+      --fee-rate 1
+      bcrt1qs758ursh4q9z627kt3pp5yysm78ddny6txaqgw 500:{}
+    ",
+    Rune(RUNE),
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Send>();
+
+  core.mine_blocks(1);
+
+  let (a_block, a_tx) = core.tx_index(send.txid);
+  let (b_block, b_tx) = core.tx_index(b.output.reveal);
+
+  let seller_address = CommandBuilder::new("--regtest wallet receive")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<ord::subcommand::wallet::receive::Output>()
+    .addresses
+    .into_iter()
+    .next()
+    .unwrap()
+    .require_network(Network::Regtest)
+    .unwrap();
+
+  let merge = core.broadcast_tx(TransactionTemplate {
+    inputs: &[(a_block, a_tx, 1, default()), (b_block, b_tx, 1, default())],
+    recipient: Some(seller_address.clone()),
+    ..default()
+  });
+
+  core.mine_blocks(1);
+
+  core.state().remove_wallet_address(seller_address.clone());
+
+  let utxo0 = OutPoint {
+    txid: merge,
+    vout: 0,
+  };
+
+  let utxo1 = OutPoint {
+    txid: send.txid,
+    vout: 2,
+  };
+
+  let buyer_postage = 8_000;
+  let seller_postage = 30_000;
+
+  let create = CommandBuilder::new(format!(
+    "--regtest wallet offer create --rune {}:{} --amount 1btc --postage {}sat --fee-rate 1 --utxo {} --utxo {}",
+    1000,
+    rune,
+    buyer_postage,
+    utxo0,
+    utxo1,
+  ))
+  .core(&core)
+  .ord(&ord)
+  .run_and_deserialize_output::<Create>();
+
+  assert_eq!(
+    create
+      .seller_address
+      .clone()
+      .require_network(Network::Regtest)
+      .unwrap(),
+    seller_address.clone(),
+  );
+
+  assert_eq!(create.inscription, None);
+
+  assert_eq!(
+    create.rune,
+    Some(Outgoing::Rune {
+      rune: SpacedRune {
+        rune: Rune(RUNE),
+        spacers: 0,
+      },
+      decimal: "1000".parse().unwrap(),
+    })
+  );
+
+  let outputs = CommandBuilder::new("--regtest wallet outputs")
+    .core(&core)
+    .ord(&ord)
+    .run_and_deserialize_output::<Vec<ord::subcommand::wallet::outputs::Output>>();
+
+  let psbt = Psbt::deserialize(&base64_decode(&create.psbt).unwrap()).unwrap();
+
+  let payment_input = psbt.unsigned_tx.input[2].previous_output;
+
+  assert!(outputs.iter().any(|output| output.output == payment_input));
+
+  let payment_input_value = outputs
+    .iter()
+    .find(|o| o.output == payment_input)
+    .map_or(0, |o| o.amount);
+
+  for (i, output) in psbt.unsigned_tx.output.iter().enumerate() {
+    if i > 1 && !output.script_pubkey.is_op_return() {
+      assert!(core.state().is_wallet_address(
+        &Address::from_script(&output.script_pubkey, Network::Regtest).unwrap()
+      ));
+    }
+  }
+
+  let payment = 100_000_000;
+  let fee = 339;
+
+  let fee_rate = fee as f64 / psbt.unsigned_tx.vsize() as f64;
+
+  assert!((fee_rate - 1.0).abs() < 0.1);
+
+  let runestone = Runestone {
+    edicts: vec![Edict {
+      amount: 0,
+      id: a.id,
+      output: 2,
+    }],
+    ..default()
+  };
+
+  pretty_assertions::assert_eq!(
+    psbt.unsigned_tx,
+    Transaction {
+      version: Version(2),
+      lock_time: LockTime::ZERO,
+      input: vec![
+        TxIn {
+          previous_output: utxo0,
+          script_sig: ScriptBuf::new(),
+          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+          witness: Witness::new(),
+        },
+        TxIn {
+          previous_output: utxo1,
+          script_sig: ScriptBuf::new(),
+          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+          witness: Witness::new(),
+        },
+        TxIn {
+          previous_output: payment_input,
+          script_sig: ScriptBuf::new(),
+          sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+          witness: Witness::new(),
+        }
+      ],
+      output: vec![
+        TxOut {
+          value: Amount::from_sat(seller_postage),
+          script_pubkey: seller_address.clone().into(),
+        },
+        TxOut {
+          value: Amount::from_sat(payment),
+          script_pubkey: seller_address.clone().into(),
+        },
+        TxOut {
+          value: Amount::from_sat(buyer_postage),
+          script_pubkey: psbt.unsigned_tx.output[2].script_pubkey.clone(),
+        },
+        TxOut {
+          value: Amount::ZERO,
+          script_pubkey: runestone.encipher(),
+        },
+        TxOut {
+          value: Amount::from_sat(payment_input_value - payment - buyer_postage - fee),
+          script_pubkey: psbt.unsigned_tx.output[4].script_pubkey.clone(),
+        },
+      ],
+    }
+  );
+
+  for (i, input) in psbt.inputs.iter().enumerate() {
+    if i <= 1 {
+      assert_eq!(input.final_script_witness, None);
+    } else {
+      assert!(input.final_script_witness.is_some());
+    }
+  }
+}
+
+#[test]
 fn rune_must_exist() {
   let core = mockcore::builder().network(Network::Regtest).build();
 
@@ -758,8 +1124,7 @@ fn utxo_holds_more_runes_than_expected() {
   .core(&core)
   .ord(&ord)
   .expected_stderr(format!(
-    "error: utxo {} holds more {} than expected (750 > 1)\n",
-    outpoint,
+    "error: utxo(s) hold more {} than expected (750 > 1)\n",
     Rune(RUNE)
   ))
   .expected_exit_code(1)
@@ -804,8 +1169,7 @@ fn utxo_holds_fewer_runes_than_required() {
   .core(&core)
   .ord(&ord)
   .expected_stderr(format!(
-    "error: utxo {} holds less {} than required (750 < 1000)\n",
-    outpoint,
+    "error: utxo(s) hold less {} than required (750 < 1000)\n",
     Rune(RUNE)
   ))
   .expected_exit_code(1)


### PR DESCRIPTION
## TLDR
This PR implements issue #4183 and updates the documentation in `wallet.md`. It includes an optional `--postage` argument in `offer create`, which lets the user designate the minimum postage on their receive output.

## Key Features

- Create a buy offer for a rune balance held across one or more UTXOs
- Handle UTXOs that hold multiple types of runes
- Use `--postage` to set the minimum postage on the buyer's receive output, which applies to both inscription and rune buy offers (default: 10,000 sats)

## Implementation Details

### Transaction construction
- If a UTXO holds multiple runes, two seller outputs are created, one to receive the unsold runes and one to receive payment.
- If a UTXO holds multiple runes, the first two outputs spend to the seller's address and the fourth output contains a runestone that sends the entire balance of the rune of interest to the buyer.
- If more than one `--utxo` is provided, the `script_pubkey` of the first UTXO is used as the seller's address.

### An error is thrown in `offer create` if:
- Both `--inscription` and `--rune` are present
- The purchased UTXO does not match a `--utxo`, if present (this applies to both inscription and rune buy offers)

### An error is thrown in `offer accept` if:
- Both `--inscription` and `--rune` are present
- A UTXO holds a single rune and a runestone is present.
- A UTXO holds multiple runes and no runestone is present.
- A UTXO holds multiple runes and the runestone does not match the runestone used in `offer create`.
- A UTXO holds multiple runes and the `script_pubkey` of the first output does not match that of one of the seller's UTXOs.

Other error conditions exist, but these are the most pertinent ones. Each error condition has an independent test case.

## Documentation

### Creating an Inscription or Runes Buy Offer

Bid `AMOUNT` on the inscription `INSCRIPTION_ID` using:

```
ord wallet offer create --inscription <INSCRIPTION_ID> --fee-rate <FEE_RATE> --amount <AMOUNT>
```

Bid `AMOUNT` on the rune balance `DECIMAL:RUNE` at `UTXO` using:

```
ord wallet offer create --rune <DECIMAL:RUNE> --fee-rate <FEE_RATE> --amount <AMOUNT> --utxo <UTXO>
```

### Accepting an Inscription or Runes Buy Offer

Accept the offer to buy the inscription `INSCRIPTION_ID` for `AMOUNT` in `PSBT` using:

```
ord wallet offer accept --inscription <INSCRIPTION_ID> --amount <AMOUNT> --psbt <PSBT>
```

Accept the offer to buy the rune balance `DECIMAL:RUNE` in `PSBT` using:

```
ord wallet offer accept --rune <DECIMAL:RUNE> --amount <AMOUNT> --psbt <PSBT>
```